### PR TITLE
feat: add read-only claims evidence service

### DIFF
--- a/src/procurement_intelligence_lab/application/evidence_service.py
+++ b/src/procurement_intelligence_lab/application/evidence_service.py
@@ -4,7 +4,14 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from procurement_intelligence_lab.application.pipeline import run_bom_pipeline
-from procurement_intelligence_lab.domain.bom import Bom, EvidenceRef, QueryResult, bom_cost, distinct_skus, gpu_quantity
+from procurement_intelligence_lab.domain.bom import (
+    Bom,
+    EvidenceRef,
+    QueryResult,
+    bom_cost,
+    distinct_skus,
+    gpu_quantity,
+)
 from procurement_intelligence_lab.domain.evidence import EvidenceChain
 
 

--- a/src/procurement_intelligence_lab/application/evidence_service.py
+++ b/src/procurement_intelligence_lab/application/evidence_service.py
@@ -1,0 +1,38 @@
+"""Read-only claims and evidence service for inspector and chat adapters."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from procurement_intelligence_lab.application.pipeline import run_bom_pipeline
+from procurement_intelligence_lab.domain.bom import Bom, EvidenceRef, QueryResult, bom_cost, distinct_skus, gpu_quantity
+from procurement_intelligence_lab.domain.evidence import EvidenceChain
+
+
+class ClaimKind(StrEnum):
+    DISTINCT_SKUS = "distinct_skus"
+    GPU_QUANTITY = "gpu_quantity"
+    BOM_COST = "bom_cost"
+
+
+@dataclass(frozen=True)
+class EvidenceBackedClaim:
+    kind: ClaimKind
+    value: object
+    status: str
+    evidence: tuple[EvidenceRef, ...]
+    execution_trace: EvidenceChain
+
+
+def inspect_bom_claims(
+    bom: Bom, canonical_candidates: tuple[str, ...]
+) -> tuple[EvidenceBackedClaim, ...]:
+    trace = run_bom_pipeline(bom, canonical_candidates).evidence
+    queries: tuple[tuple[ClaimKind, QueryResult], ...] = (
+        (ClaimKind.DISTINCT_SKUS, distinct_skus(bom)),
+        (ClaimKind.GPU_QUANTITY, gpu_quantity(bom)),
+        (ClaimKind.BOM_COST, bom_cost(bom)),
+    )
+    return tuple(
+        EvidenceBackedClaim(kind, query.value, str(query.status), query.evidence, trace)
+        for kind, query in queries
+    )

--- a/tests/unit/test_evidence_service.py
+++ b/tests/unit/test_evidence_service.py
@@ -1,0 +1,34 @@
+from decimal import Decimal
+
+from procurement_intelligence_lab.application.evidence_service import (
+    ClaimKind,
+    inspect_bom_claims,
+)
+from procurement_intelligence_lab.domain.bom import Bom, BomLine, EvidenceRef
+
+
+def test_claim_service_exposes_deterministic_values_and_execution_trace() -> None:
+    evidence = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B", "C", "D"))
+    bom = Bom(
+        "bom.xlsx",
+        (
+            BomLine("GPU-A", "GPU accelerator", Decimal(4), Decimal(100), evidence),
+            BomLine("CPU-A", "CPU", Decimal(2), Decimal(50), evidence),
+        ),
+    )
+
+    claims = inspect_bom_claims(bom, ("GPU-A", "CPU-A"))
+
+    assert [claim.kind for claim in claims] == [
+        ClaimKind.DISTINCT_SKUS,
+        ClaimKind.GPU_QUANTITY,
+        ClaimKind.BOM_COST,
+    ]
+    assert claims[-1].value == Decimal(500)
+    assert claims[-1].evidence == (evidence, evidence)
+    assert [node.label for node in claims[-1].execution_trace.nodes] == [
+        "source assertions",
+        "entity resolution",
+        "operational state",
+        "reconciliation",
+    ]


### PR DESCRIPTION
## What changed

- Add a framework-independent read-only service that exposes deterministic BOM claims with source evidence and an execution trace.
- Add a unit test for the inspector/chat adapter contract.

## Why

The forthcoming browser inspector and chat layer need a first-class claims/evidence boundary. They may explain or select claims, but cannot bypass deterministic computation or provenance.