### PR TITLE
feat: add constrained chat claim adapter

### DIFF
--- a/src/procurement_intelligence_lab/application/chat.py
+++ b/src/procurement_intelligence_lab/application/chat.py
@@ -1,0 +1,34 @@
+"""Constrained natural-language adapter over evidence-backed procurement claims."""
+
+from procurement_intelligence_lab.application.evidence_service import (
+    ClaimKind,
+    EvidenceBackedClaim,
+    inspect_bom_claims,
+)
+from procurement_intelligence_lab.domain.bom import Bom
+
+
+class UnsupportedQuestionError(ValueError):
+    """Raised when a question has no approved deterministic claim route."""
+
+
+def answer_question(
+    question: str, bom: Bom, canonical_candidates: tuple[str, ...]
+) -> EvidenceBackedClaim:
+    normalized = " ".join(question.casefold().replace("-", " ").split())
+    if "gpu" in normalized and any(token in normalized for token in ("how many", "quantity")):
+        kind = ClaimKind.GPU_QUANTITY
+    elif any(token in normalized for token in ("cost", "price", "total")):
+        kind = ClaimKind.BOM_COST
+    elif "sku" in normalized:
+        kind = ClaimKind.DISTINCT_SKUS
+    else:
+        raise UnsupportedQuestionError(
+            "no approved deterministic claim route for this question"
+        )
+
+    return next(
+        claim
+        for claim in inspect_bom_claims(bom, canonical_candidates)
+        if claim.kind is kind
+    )

--- a/src/procurement_intelligence_lab/application/chat.py
+++ b/src/procurement_intelligence_lab/application/chat.py
@@ -23,12 +23,8 @@ def answer_question(
     elif "sku" in normalized:
         kind = ClaimKind.DISTINCT_SKUS
     else:
-        raise UnsupportedQuestionError(
-            "no approved deterministic claim route for this question"
-        )
+        raise UnsupportedQuestionError("no approved deterministic claim route for this question")
 
     return next(
-        claim
-        for claim in inspect_bom_claims(bom, canonical_candidates)
-        if claim.kind is kind
+        claim for claim in inspect_bom_claims(bom, canonical_candidates) if claim.kind is kind
     )

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -1,0 +1,34 @@
+from decimal import Decimal
+
+import pytest
+
+from procurement_intelligence_lab.application.chat import (
+    UnsupportedQuestionError,
+    answer_question,
+)
+from procurement_intelligence_lab.application.evidence_service import ClaimKind
+from procurement_intelligence_lab.domain.bom import Bom, BomLine, EvidenceRef
+
+
+def bom() -> Bom:
+    evidence = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B", "C", "D"))
+    return Bom(
+        "bom.xlsx",
+        (
+            BomLine("GPU-A", "GPU accelerator", Decimal(4), Decimal(100), evidence),
+            BomLine("CPU-A", "CPU", Decimal(2), Decimal(50), evidence),
+        ),
+    )
+
+
+def test_question_routes_to_evidence_backed_deterministic_claim() -> None:
+    result = answer_question("How many GPUs are in the BOM?", bom(), ("GPU-A", "CPU-A"))
+
+    assert result.kind is ClaimKind.GPU_QUANTITY
+    assert result.value == Decimal(4)
+    assert result.execution_trace.claim == "BOM operational state"
+
+
+def test_unapproved_question_abstains() -> None:
+    with pytest.raises(UnsupportedQuestionError, match="no approved"):
+        answer_question("Which vendor should I choose?", bom(), ("GPU-A", "CPU-A"))


### PR DESCRIPTION
## What changed

- Route approved procurement questions to deterministic, evidence-backed claims.
- Abstain from unsupported questions instead of inventing an answer.
- Add tests for an approved GPU-quantity question and an unsupported vendor-selection question.

## Why

This creates the safe inner boundary for the showcase chat: it can select an approved deterministic claim and present its execution trace, but cannot manufacture facts or recommendations.