### PR TITLE
docs: synchronize architecture plans and delivery milestones

### DIFF
--- a/.agents/skills/architecture-plan-sync/SKILL.md
+++ b/.agents/skills/architecture-plan-sync/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: architecture-plan-sync
+description: Keep repository architecture, delivery milestones, GitHub work items, and implementation status synchronized.
+---
+
+# Architecture plan synchronization
+
+Use this skill whenever planning, implementing, reviewing, or reporting repository work.
+
+## Before coding
+
+1. Read `docs/development/milestone-map.md`.
+2. Read `docs/development/github-plan.md` and the relevant architecture/ADR documents.
+3. Identify the smallest vertical delivery slice.
+4. Associate it with one primary milestone and GitHub issue.
+5. Decide whether the change affects an invariant, boundary, or public contract.
+
+## During coding
+
+- Keep implementation and acceptance evidence together.
+- Preserve the distinction between target architecture and capabilities on `main`.
+- Do not infer milestone status from branch names or PR numbers.
+- If the implementation sequence changes, update the milestone map in the same change.
+
+## Before opening a PR
+
+Confirm that the PR states:
+
+- primary milestone and linked issue;
+- implementation scope and acceptance evidence;
+- tests/evaluation performed;
+- documentation and ADR impact.
+
+Update the README, roadmap, milestone map, or ADRs when the change makes them stale. Use an ADR for durable architecture decisions, not for routine status bookkeeping.
+
+## Before declaring completion
+
+A milestone is complete only when implementation, tests, documentation, and acceptance evidence are merged to `main`. Report any remaining drift explicitly.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,15 +2,28 @@
 
 ## Why
 
+## Milestone and issue
+
+- Primary milestone:
+- Linked issue:
+- Acceptance evidence:
+
 ## Evidence / validation
 
 ## Architectural impact
-- [ ] No ADR needed
+
+- [ ] No architecture boundary, invariant, or public contract changed
 - [ ] ADR added or updated
+- [ ] Existing ADR/docs reviewed for drift
 
-## Checklist
-- [ ] `make check`
-- [ ] Evidence/provenance preserved
+## Synchronization
+
+- [ ] Milestone map updated if scope/status changed
+- [ ] README/roadmap updated if implementation status changed
+- [ ] Public contracts and evidence semantics documented
 - [ ] No confidential data
-- [ ] Docs and evaluation updated
 
+## Checks
+
+- [ ] `make check`
+- [ ] Relevant tests/evaluation run

--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@ Procurement Intelligence Lab is a public, synthetic-data reference architecture 
 
 ## Showcase
 
-The intended showcase is a chat interface paired with an evidence inspector and source viewer. A material answer claim can be opened from calculation, through operational state, reconciliation, canonical entities, resolution decisions, source assertions, mapped fields, document structure, and the original synthetic document. Epistemic status and correction/review actions remain visible.
+The showcase is a chat interface paired with an evidence inspector and source viewer. A material answer claim can be opened from calculation, through operational state, reconciliation, canonical entities, resolution decisions, source assertions, mapped fields, document structure, and the original synthetic document. Epistemic status and correction/review actions remain visible.
 
 ## Architecture
 
-Artifacts flow through `StructuredDocument → MappedDocument → normalized observations → source assertions → entity mentions → resolution decisions → canonicalized assertions → reconciliation → operational state → derived intelligence`. Postgres is the canonical store; search, vector, and graph systems are projections. Core semantics are framework-independent Python dataclasses behind ports and adapters.
+Artifacts flow through `StructuredDocument → MappedDocument → normalized observations → source assertions → entity mentions → resolution decisions → canonicalized assertions → reconciliation → operational state → derived intelligence`. Postgres is the intended canonical store; search, vector, and graph systems are replaceable projections. Core semantics are framework-independent Python dataclasses behind ports and adapters.
 
 ## Status
 
-M1 is implemented: a dependency-free XLSX BOM adapter, typed line-level evidence, deterministic SKU/GPU/cost queries, explicit cost abstention, source assertions, conservative entity resolution, operational-state projection, reconciliation, and a framework-independent evidence chain.
+The initial vertical slice is complete: a dependency-free XLSX BOM adapter, typed line-level evidence, deterministic SKU/GPU/cost queries, explicit cost abstention, source assertions, conservative entity resolution, operational-state projection, reconciliation, and a framework-independent evidence chain.
 
-The runnable demo parses a committed synthetic workbook and emits deterministic claims, reconciled operational state, and the evidence stages needed for drill-down. Production document structuring, persistence, review UI, and broader XLSX support remain later slices.
+The current implementation also includes the claims/evidence service and a constrained chat adapter. A dependency-free local HTTP chat/evidence inspector is in progress in [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82). Durable identifiers, persistence, review workflows, retrieval projections, and product-feedback capture remain planned.
+
+The canonical delivery map is [docs/development/milestone-map.md](docs/development/milestone-map.md). Changes to architecture or delivery status must follow the synchronization policy in [ADR-012](docs/adr/012-plan-and-milestone-synchronization.md).
 
 ## Local entry points
 

--- a/docs/adr/012-plan-and-milestone-synchronization.md
+++ b/docs/adr/012-plan-and-milestone-synchronization.md
@@ -1,0 +1,50 @@
+# ADR-012: Synchronize delivery plans with implementation
+
+Status: accepted
+
+## Context
+
+The repository has two related but different planning needs:
+
+- architecture documents describe durable boundaries, invariants, and trade-offs;
+- GitHub milestones and PRs describe the incremental delivery sequence.
+
+The original plan allowed these to drift because it described an ideal layer-by-layer architecture while implementation proceeded through vertical slices. Merged PRs had no explicit requirement to update status documents or record their milestone mapping.
+
+## Decision
+
+Use three complementary sources:
+
+1. GitHub Issues and Project fields track actionable work and ownership.
+2. `docs/development/milestone-map.md` is the canonical implementation-to-architecture status map.
+3. ADRs and architecture documents record durable decisions, invariants, and public contracts.
+
+Every implementation PR must name a primary milestone and issue. When scope or status changes, the PR must update the milestone map. When a boundary, invariant, or public contract changes, it must add or amend an ADR and update affected documentation.
+
+Milestones are vertical delivery slices. They may cross multiple architectural layers. A milestone is complete only when implementation, tests, documentation, and acceptance evidence are present on `main`.
+
+## Consequences
+
+Agents can use the milestone map to orient before coding and to report status without reconstructing history from PRs. Documentation changes become part of the definition of done. The map introduces a small maintenance obligation, but prevents the more costly ambiguity between intended architecture and delivered capability.
+
+This policy does not require an ADR for ordinary refactoring or every documentation edit. It requires an ADR when a durable architectural decision changes.
+
+## Agent and review procedure
+
+Before implementation:
+
+- read the milestone map and relevant ADRs;
+- choose or create the smallest vertical issue;
+- state the expected documentation and acceptance evidence.
+
+Before opening a PR:
+
+- verify the milestone and issue are named;
+- update the map if implementation status or scope changed;
+- review README, roadmap, and related ADRs for stale claims;
+- run the project checks and include their results.
+
+After merge:
+
+- mark the issue/milestone status consistently in GitHub;
+- do not mark a milestone complete until its acceptance evidence is on `main`.

--- a/docs/development/github-plan.md
+++ b/docs/development/github-plan.md
@@ -1,30 +1,50 @@
 # GitHub operating plan
 
-## Milestones
+## Source of truth
 
-Create these milestones in order: M0 Engineering & Architecture Harness; M1 Synthetic Document Vertical Slice; M2 Assertion Ledger & Provenance; M3 Deterministic Entity Resolution; M4 Reconciliation & Operational State; M5 Evidence-First Chat UX; M6 Retrieval Projections; M7 Intelligence & Forecasting; M8 Guarded Agent Tools; M9 Integrated Demo.
+GitHub Issues and Project fields track work items; [milestone-map.md](milestone-map.md) tracks the relationship between delivery slices and the architecture. This file describes operating conventions and the forward-looking capability sequence. It is not a substitute for current implementation status.
+
+Every implementation PR must:
+
+1. identify one primary milestone and linked issue;
+2. state whether it changes an invariant, boundary, or public contract;
+3. update the milestone map when status or scope changes;
+4. update the README, roadmap, or relevant ADR when the change makes existing documentation inaccurate;
+5. include validation evidence, including documentation checks where applicable.
+
+## Delivery sequence
+
+The delivery sequence is intentionally vertical and may cross architectural layers:
+
+- M0 Engineering & Architecture Harness — complete
+- M1 Synthetic Document Vertical Slice — complete
+- M2 Evidence Contract & Golden Tests — complete
+- M3 Claims / Evidence Application Service — complete
+- M4 Constrained Chat Routing — complete
+- M5 Local HTTP Chat Inspector — in progress
+- M6 Durable Identity, Source Viewer & Review Context — planned
+- M7 Append-Only Persistence & Temporal State — planned
+- M8 Retrieval Projections & Review UI — planned
+- M9 Guarded Actions, Product Signals & Evaluation — planned
+
+A milestone is complete only when its implementation, tests, documentation, and acceptance evidence are present.
 
 ## Project fields and views
 
-Use a GitHub Project with fields: Status, Area, Type, Priority, Risk, Agentability, Evidence Required, Milestone, and Decision Needed. Views: M0 board, milestone roadmap, evidence-gated queue, architecture decisions, and evaluation results. Keep labels focused on durable facets and use fields for workflow state to avoid duplication.
+Use a GitHub Project with fields: Status, Area, Type, Priority, Risk, Agentability, Evidence Required, Milestone, and Decision Needed. Views: milestone roadmap, evidence-gated queue, architecture decisions, and evaluation results. Keep labels focused on durable facets and use fields for workflow state to avoid duplication.
 
 ## Labels
 
 Suggested labels are `area:architecture`, `area:domain`, `area:ingestion`, `area:provenance`, `area:entity-resolution`, `area:retrieval`, `area:ux`, `area:agents`, `area:evaluation`, `type:adr`, `type:feature`, `type:benchmark`, `type:docs`, `type:chore`, `risk:high`, `risk:medium`, `risk:low`, `evidence:required`, and `good-first-slice`. Milestones and Project fields carry sequencing and status.
 
-## M0 queue
+## Initial queue
 
-- Establish repository constitution and architecture invariants.
-- Establish semantic model and database conceptual model.
-- Establish evidence inspector contract and UX drill-down chain.
-- Establish ADR set and benchmark obligations.
-- Establish Python/tooling/agent-loop conventions and CI.
-- Define synthetic data specification and evaluation manifests.
-- Create the first intentionally tiny M1 issue: parse one synthetic XLSX BOM into intermediate/domain structures and display or persist through CLI.
-
-Only the small M1 epic and a bounded set of M2/M3/M5 epics should be created initially. Avoid speculative issue floods.
+- Keep the semantic model and architecture invariants current.
+- Maintain the evidence inspector contract and UX drill-down chain.
+- Add stable identifiers before persistence or multi-document review.
+- Define the synthetic data specification and evaluation manifests.
+- Prefer small vertical issues with explicit acceptance evidence over speculative issue floods.
 
 ## Runner security
 
 CI starts on GitHub-hosted runners. A future secure self-hosted DGX runner must be isolated, ephemeral or resettable, least-privilege, secret-free by default, and limited to trusted post-merge workflows. Untrusted public pull-request code is explicitly blocked from trusted self-hosted runners; public PRs use GitHub-hosted runners only.
-

--- a/docs/development/milestone-map.md
+++ b/docs/development/milestone-map.md
@@ -1,0 +1,36 @@
+# Delivery milestone map
+
+This is the canonical map from the current implementation to the architecture. Milestones are delivery slices, not isolated layers; one slice may cross domain, application, adapter, test, and documentation boundaries.
+
+| Milestone | Delivered capability | Status | Primary evidence |
+|---|---|---|---|
+| M0 | Repository harness, conventions, CI, invariants | Complete | `docs/architecture/invariants.md`, CI |
+| M1 | Synthetic XLSX BOM vertical slice | Complete | `src/procurement_intelligence_lab/adapters/xlsx.py`, demo |
+| M2 | Evidence contract and golden tests | Complete | `tests/unit/test_evidence_contract.py` |
+| M3 | Claims/evidence application service | Complete | `application/evidence_service.py` |
+| M4 | Constrained deterministic chat routing | Complete | `application/chat.py` |
+| M5 | Local HTTP chat/evidence inspector | In progress | [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82) |
+| M6 | Durable identifiers, source viewer, and review context | Planned | Stable claim/assertion/mention/decision IDs |
+| M7 | Append-only persistence and temporal/as-of state | Planned | Ledger schema, migrations, rebuildable projections |
+| M8 | Retrieval projections and review UI | Planned | Labeled retrieval evaluation and review workflows |
+| M9 | Guarded actions, product signals, and integrated evaluation | Planned | Approval gates, sanitized feedback loop, release evidence |
+
+## Status rules
+
+- **Planned** means the capability is not yet implemented on `main`.
+- **In progress** means an open PR or active implementation exists.
+- **Complete** means implementation, tests, documentation, and acceptance evidence are present on `main`.
+- A merged PR may complete only part of a milestone; update this table when that happens.
+- If the implementation sequence changes, update this map and the GitHub operating plan in the same PR.
+
+## PR mapping
+
+The merged implementation sequence is:
+
+- M1: PR #77
+- M2: PR #79
+- M3: PR #80
+- M4: PR #81
+- M5: PR #82, pending merge
+
+This mapping is deliberately explicit so future agents do not infer milestone status from PR numbers or filenames.


### PR DESCRIPTION
## What changed

- Add the canonical implementation-to-architecture milestone map.
- Add ADR-012 defining plan, milestone, issue, and documentation synchronization.
- Add the repository `architecture-plan-sync` agent skill.
- Strengthen the pull request template with milestone, issue, acceptance-evidence, and documentation checks.
- Update the README and GitHub operating plan to reflect the actual M1–M5 delivery sequence.

## Why

The architecture plan was describing an ideal layer-by-layer sequence while implementation proceeded through vertical slices. This caused README status, milestone names, ADRs, and merged PRs to diverge.

The new policy separates durable architecture decisions from delivery tracking and makes synchronization part of the definition of done.

## Validation

Documentation/process-only change. The existing CI check is expected to validate formatting and tests; no runtime behavior was changed.