### PR TITLE
feat: add stable evidence and claim identifiers

### DIFF
--- a/docs/adr/013-stable-evidence-identifiers.md
+++ b/docs/adr/013-stable-evidence-identifiers.md
@@ -1,0 +1,24 @@
+# ADR-013: Stable identifiers for evidence navigation
+
+Status: accepted
+
+## Context
+
+The inspector, future source viewer, review workflow, and product-feedback loop need to refer to the same claim and evidence objects across requests. Display labels and array positions are not durable references. Persistence is not yet part of the repository, so identifiers must be useful before a database exists.
+
+## Decision
+
+Use deterministic, opaque identifiers derived from semantic provenance:
+
+- `EvidenceRef.evidence_id` identifies an artifact location and its content hash.
+- `EvidenceNode.node_id` identifies a stage, status, and its evidence references.
+- `EvidenceChain.chain_id` identifies a claim trace and ordered nodes.
+- `EvidenceBackedClaim.claim_id` identifies the claim kind, value, status, trace, and evidence.
+
+Identifiers are produced by a framework-independent hashing helper. They are stable for identical semantic inputs and change when the referenced evidence or claim context changes. They are navigation and correlation identifiers, not database primary keys or authorization credentials.
+
+## Consequences
+
+The HTTP inspector can expose references that a source viewer or feedback report can retain without copying source contents. The identifiers remain deterministic in tests and local demos. A future persistence layer may store them as natural correlation keys, but may introduce separate database identities if lifecycle or tenancy requires them.
+
+Changing the canonical serialization inputs is a compatibility change and requires an ADR or amendment. Identifiers must not be used to infer authority: provenance, epistemic status, and review state remain separate fields.

--- a/docs/development/milestone-map.md
+++ b/docs/development/milestone-map.md
@@ -9,8 +9,8 @@ This is the canonical map from the current implementation to the architecture. M
 | M2 | Evidence contract and golden tests | Complete | `tests/unit/test_evidence_contract.py` |
 | M3 | Claims/evidence application service | Complete | `application/evidence_service.py` |
 | M4 | Constrained deterministic chat routing | Complete | `application/chat.py` |
-| M5 | Local HTTP chat/evidence inspector | In progress | [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82) |
-| M6 | Durable identifiers, source viewer, and review context | Planned | Stable claim/assertion/mention/decision IDs |
+| M5 | Local HTTP chat/evidence inspector | Complete | [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82) |
+| M6 | Durable identifiers, source viewer, and review context | In progress | [Issue #85](https://github.com/stauntonjr/procurement-intelligence-lab/issues/85), ADR-013 |
 | M7 | Append-only persistence and temporal/as-of state | Planned | Ledger schema, migrations, rebuildable projections |
 | M8 | Retrieval projections and review UI | Planned | Labeled retrieval evaluation and review workflows |
 | M9 | Guarded actions, product signals, and integrated evaluation | Planned | Approval gates, sanitized feedback loop, release evidence |
@@ -31,6 +31,7 @@ The merged implementation sequence is:
 - M2: PR #79
 - M3: PR #80
 - M4: PR #81
-- M5: PR #82, pending merge
+- M5: PR #82
+- M6: Issue #85, implementation in progress
 
 This mapping is deliberately explicit so future agents do not infer milestone status from PR numbers or filenames.

--- a/src/procurement_intelligence_lab/application/evidence_service.py
+++ b/src/procurement_intelligence_lab/application/evidence_service.py
@@ -13,6 +13,7 @@ from procurement_intelligence_lab.domain.bom import (
     gpu_quantity,
 )
 from procurement_intelligence_lab.domain.evidence import EvidenceChain
+from procurement_intelligence_lab.domain.identity import stable_id
 
 
 class ClaimKind(StrEnum):
@@ -28,6 +29,17 @@ class EvidenceBackedClaim:
     status: str
     evidence: tuple[EvidenceRef, ...]
     execution_trace: EvidenceChain
+
+    @property
+    def claim_id(self) -> str:
+        return stable_id(
+            "claim",
+            self.kind.value,
+            str(self.value),
+            self.status,
+            self.execution_trace.chain_id,
+            tuple(ref.evidence_id for ref in self.evidence),
+        )
 
 
 def inspect_bom_claims(

--- a/src/procurement_intelligence_lab/domain/bom.py
+++ b/src/procurement_intelligence_lab/domain/bom.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from decimal import Decimal
 from enum import StrEnum
 
+from procurement_intelligence_lab.domain.identity import stable_id
+
 
 class EpistemicStatus(StrEnum):
     OBSERVED = "observed"
@@ -18,6 +20,17 @@ class EvidenceRef:
     sheet: str
     row: int
     cells: tuple[str, ...]
+
+    @property
+    def evidence_id(self) -> str:
+        return stable_id(
+            "evidence",
+            self.artifact_id,
+            self.content_hash,
+            self.sheet,
+            self.row,
+            self.cells,
+        )
 
 
 @dataclass(frozen=True)

--- a/src/procurement_intelligence_lab/domain/evidence.py
+++ b/src/procurement_intelligence_lab/domain/evidence.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from procurement_intelligence_lab.domain.bom import EvidenceRef
+from procurement_intelligence_lab.domain.identity import stable_id
 from procurement_intelligence_lab.domain.resolution import ResolutionDecision
 from procurement_intelligence_lab.domain.state import OperationalBomLine
 
@@ -22,11 +23,29 @@ class EvidenceNode:
     evidence: tuple[EvidenceRef, ...]
     status: str
 
+    @property
+    def node_id(self) -> str:
+        return stable_id(
+            "evidence-node",
+            self.kind.value,
+            self.label,
+            self.status,
+            tuple(ref.evidence_id for ref in self.evidence),
+        )
+
 
 @dataclass(frozen=True)
 class EvidenceChain:
     claim: str
     nodes: tuple[EvidenceNode, ...]
+
+    @property
+    def chain_id(self) -> str:
+        return stable_id("evidence-chain", self.claim, tuple(node.node_id for node in self.nodes))
+
+    @property
+    def claim_id(self) -> str:
+        return stable_id("claim", self.claim, self.chain_id)
 
 
 def source_chain(claim: str, evidence: tuple[EvidenceRef, ...]) -> EvidenceChain:

--- a/src/procurement_intelligence_lab/domain/identity.py
+++ b/src/procurement_intelligence_lab/domain/identity.py
@@ -1,0 +1,19 @@
+"""Deterministic identifiers for evidence-backed domain objects."""
+
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+
+
+def stable_id(namespace: str, *parts: object) -> str:
+    """Return a stable, opaque identifier for a semantic object."""
+    payload = json.dumps(
+        [namespace, *parts],
+        ensure_ascii=True,
+        sort_keys=True,
+        default=str,
+        separators=(",", ":"),
+    )
+    digest = sha256(payload.encode("utf-8")).hexdigest()[:24]
+    return f"{namespace}:{digest}"

--- a/src/procurement_intelligence_lab/interfaces/web.py
+++ b/src/procurement_intelligence_lab/interfaces/web.py
@@ -44,13 +44,24 @@ def claim_payload(question: str) -> dict[str, object]:
     return {
         "question": question,
         "claim": claim.kind,
+        "claim_id": claim.claim_id,
         "value": value,
         "status": claim.status,
-        "evidence": [ref.__dict__ for ref in claim.evidence],
+        "evidence": [
+            {**ref.__dict__, "evidence_id": ref.evidence_id} for ref in claim.evidence
+        ],
         "execution_trace": {
             "claim": claim.execution_trace.claim,
+            "claim_id": claim.execution_trace.claim_id,
+            "chain_id": claim.execution_trace.chain_id,
             "nodes": [
-                {"kind": node.kind, "label": node.label, "status": node.status}
+                {
+                    "node_id": node.node_id,
+                    "kind": node.kind,
+                    "label": node.label,
+                    "status": node.status,
+                    "evidence_ids": [ref.evidence_id for ref in node.evidence],
+                }
                 for node in claim.execution_trace.nodes
             ],
         },

--- a/src/procurement_intelligence_lab/interfaces/web.py
+++ b/src/procurement_intelligence_lab/interfaces/web.py
@@ -47,9 +47,7 @@ def claim_payload(question: str) -> dict[str, object]:
         "claim_id": claim.claim_id,
         "value": value,
         "status": claim.status,
-        "evidence": [
-            {**ref.__dict__, "evidence_id": ref.evidence_id} for ref in claim.evidence
-        ],
+        "evidence": [{**ref.__dict__, "evidence_id": ref.evidence_id} for ref in claim.evidence],
         "execution_trace": {
             "claim": claim.execution_trace.claim,
             "claim_id": claim.execution_trace.claim_id,

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -1,0 +1,21 @@
+from procurement_intelligence_lab.domain.bom import EvidenceRef
+from procurement_intelligence_lab.domain.evidence import source_chain
+
+
+def test_evidence_ids_are_deterministic_and_location_sensitive() -> None:
+    first = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B"))
+    same = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B"))
+    different = EvidenceRef("bom.xlsx", "hash", "BOM", 3, ("A", "B"))
+
+    assert first.evidence_id == same.evidence_id
+    assert first.evidence_id != different.evidence_id
+
+
+def test_chain_and_node_ids_are_deterministic() -> None:
+    evidence = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B"))
+    first = source_chain("gpu_quantity", (evidence,))
+    same = source_chain("gpu_quantity", (evidence,))
+
+    assert first.claim_id == same.claim_id
+    assert first.chain_id == same.chain_id
+    assert first.nodes[0].node_id == same.nodes[0].node_id

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -7,12 +7,16 @@ def test_claim_payload_exposes_trace_and_source_evidence() -> None:
     payload = claim_payload("How many GPUs are in the BOM?")
 
     assert payload["claim"] == "gpu_quantity"
+    assert isinstance(payload["claim_id"], str)
     assert payload["value"] == "4"
     assert payload["status"] == "observed"
     evidence = cast(list[dict[str, object]], payload["evidence"])
+    assert isinstance(evidence[0]["evidence_id"], str)
     assert evidence[0]["sheet"] == "BOM"
     execution_trace = cast(dict[str, object], payload["execution_trace"])
+    assert isinstance(execution_trace["chain_id"], str)
     nodes = cast(list[dict[str, object]], execution_trace["nodes"])
+    assert isinstance(nodes[0]["node_id"], str)
     assert [node["label"] for node in nodes] == [
         "source assertions",
         "entity resolution",


### PR DESCRIPTION
## Summary

Implement the first M6 slice: deterministic identifiers for evidence references, trace nodes, evidence chains, and material claims. The existing HTTP inspector now serializes those identifiers for future source navigation and review workflows.

## Milestone and issue

- Primary milestone: M6 Durable Identity, Source Viewer & Review Context
- Linked issue: #85
- Acceptance evidence: deterministic identity tests and inspector payload assertions

## What changed

- Add a framework-independent stable hashing helper.
- Add `evidence_id`, `node_id`, `chain_id`, and `claim_id`.
- Expose identifiers through `/api/ask`.
- Add ADR-013 defining the identifier contract.
- Advance the canonical milestone map.

## Architectural impact

Identifiers are correlation/navigation references, not database primary keys or authorization credentials. No persistence or database dependency is introduced.

## Validation

CI should run formatting, lint, Pyright, and tests.