### PR TITLE
feat: add read-only source viewer by evidence ID

### DIFF
--- a/docs/development/milestone-map.md
+++ b/docs/development/milestone-map.md
@@ -10,7 +10,7 @@ This is the canonical map from the current implementation to the architecture. M
 | M3 | Claims/evidence application service | Complete | `application/evidence_service.py` |
 | M4 | Constrained deterministic chat routing | Complete | `application/chat.py` |
 | M5 | Local HTTP chat/evidence inspector | Complete | [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82) |
-| M6 | Durable identifiers, source viewer, and review context | In progress | [Issue #85](https://github.com/stauntonjr/procurement-intelligence-lab/issues/85), ADR-013 |
+| M6 | Durable identifiers, source viewer, and review context | In progress | [Issues #85 and #87](https://github.com/stauntonjr/procurement-intelligence-lab/issues/87), ADR-013 |
 | M7 | Append-only persistence and temporal/as-of state | Planned | Ledger schema, migrations, rebuildable projections |
 | M8 | Retrieval projections and review UI | Planned | Labeled retrieval evaluation and review workflows |
 | M9 | Guarded actions, product signals, and integrated evaluation | Planned | Approval gates, sanitized feedback loop, release evidence |
@@ -32,6 +32,6 @@ The merged implementation sequence is:
 - M3: PR #80
 - M4: PR #81
 - M5: PR #82
-- M6: Issue #85, implementation in progress
+- M6: PR #86 for stable identifiers; source viewer in progress under Issue #87
 
 This mapping is deliberately explicit so future agents do not infer milestone status from PR numbers or filenames.

--- a/src/procurement_intelligence_lab/interfaces/web.py
+++ b/src/procurement_intelligence_lab/interfaces/web.py
@@ -33,6 +33,10 @@ form.addEventListener("submit",async event=>{event.preventDefault();const q=new 
 </script></main></body></html>"""
 
 
+class EvidenceNotFoundError(LookupError):
+    """Raised when an evidence ID is not present in the committed fixture."""
+
+
 def _fixture() -> Path:
     return Path(__file__).resolve().parents[3] / "examples" / "synthetic_bom.xlsx"
 
@@ -66,6 +70,24 @@ def claim_payload(question: str) -> dict[str, object]:
     }
 
 
+def source_payload(evidence_id: str) -> dict[str, object]:
+    bom = read_bom(_fixture())
+    for line in bom.lines:
+        evidence = line.evidence
+        if evidence.evidence_id == evidence_id:
+            return {
+                "evidence": {**evidence.__dict__, "evidence_id": evidence.evidence_id},
+                "line": {
+                    "sku": line.sku,
+                    "description": line.description,
+                    "quantity": str(line.quantity),
+                    "unit_price": str(line.unit_price) if line.unit_price is not None else None,
+                    "status": line.status,
+                },
+            }
+    raise EvidenceNotFoundError(f"unknown evidence ID: {evidence_id}")
+
+
 class InspectorHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         parsed = urlparse(self.path)
@@ -81,6 +103,15 @@ class InspectorHandler(BaseHTTPRequestHandler):
             except UnsupportedQuestionError as error:
                 body = json.dumps({"error": str(error)}).encode()
                 self.send_response(422)
+            self.send_header("Content-Type", "application/json")
+        elif parsed.path == "/api/source":
+            evidence_id = parse_qs(parsed.query).get("evidence_id", [""])[0]
+            try:
+                body = json.dumps(source_payload(evidence_id)).encode()
+                self.send_response(200)
+            except EvidenceNotFoundError as error:
+                body = json.dumps({"error": str(error)}).encode()
+                self.send_response(404)
             self.send_header("Content-Type", "application/json")
         else:
             body = b"not found"

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -1,6 +1,12 @@
 from typing import cast
 
-from procurement_intelligence_lab.interfaces.web import claim_payload
+import pytest
+
+from procurement_intelligence_lab.interfaces.web import (
+    EvidenceNotFoundError,
+    claim_payload,
+    source_payload,
+)
 
 
 def test_claim_payload_exposes_trace_and_source_evidence() -> None:
@@ -23,3 +29,20 @@ def test_claim_payload_exposes_trace_and_source_evidence() -> None:
         "operational state",
         "reconciliation",
     ]
+
+
+def test_source_payload_resolves_a_stable_evidence_id() -> None:
+    claim = claim_payload("How many GPUs are in the BOM?")
+    evidence = cast(list[dict[str, object]], claim["evidence"])
+    evidence_id = cast(str, evidence[0]["evidence_id"])
+
+    payload = source_payload(evidence_id)
+
+    assert payload["evidence"]["evidence_id"] == evidence_id
+    assert payload["evidence"]["sheet"] == "BOM"
+    assert payload["line"]["sku"] == "GPU-001"
+
+
+def test_source_payload_rejects_unknown_evidence_id() -> None:
+    with pytest.raises(EvidenceNotFoundError):
+        source_payload("evidence:missing")

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -37,10 +37,12 @@ def test_source_payload_resolves_a_stable_evidence_id() -> None:
     evidence_id = cast(str, evidence[0]["evidence_id"])
 
     payload = source_payload(evidence_id)
+    source_evidence = cast(dict[str, object], payload["evidence"])
+    source_line = cast(dict[str, object], payload["line"])
 
-    assert payload["evidence"]["evidence_id"] == evidence_id
-    assert payload["evidence"]["sheet"] == "BOM"
-    assert payload["line"]["sku"] == "GPU-001"
+    assert source_evidence["evidence_id"] == evidence_id
+    assert source_evidence["sheet"] == "BOM"
+    assert source_line["sku"] == "GPU-001"
 
 
 def test_source_payload_rejects_unknown_evidence_id() -> None:

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -42,7 +42,7 @@ def test_source_payload_resolves_a_stable_evidence_id() -> None:
 
     assert source_evidence["evidence_id"] == evidence_id
     assert source_evidence["sheet"] == "BOM"
-    assert source_line["sku"] == "GPU-001"
+    assert source_line["sku"] == "GPU-A"
 
 
 def test_source_payload_rejects_unknown_evidence_id() -> None:


### PR DESCRIPTION
## Summary

Add the next M6 slice: a read-only source lookup endpoint keyed by stable evidence IDs.

## Milestone and issue

- Primary milestone: M6 Durable Identity, Source Viewer & Review Context
- Linked issue: #87
- Related issue: #85
- Acceptance evidence: valid/invalid source lookup tests and updated milestone map

## What changed

- Add `source_payload(evidence_id)` to resolve a committed synthetic BOM location.
- Add `GET /api/source?evidence_id=...`.
- Return evidence provenance plus normalized BOM-line context.
- Return a safe 404 error for unknown identifiers.
- Add tests and update M6 status tracking.

## Architectural impact

The source viewer remains read-only and adapter-backed. It exposes normalized synthetic fixture context only; no persistence or direct UI-side source assembly is introduced.

## Validation

CI should run formatting, lint, Pyright, and tests.