### PR TITLE
feat: add reproducible review context contract

### DIFF
--- a/docs/adr/014-review-context-contract.md
+++ b/docs/adr/014-review-context-contract.md
@@ -1,0 +1,26 @@
+# ADR-014: Review context is a reproducible claim reference
+
+Status: accepted
+
+## Context
+
+The chat and evidence inspector need to let a user report a wrong result or source problem without asking the user to reconstruct the execution manually. Stable claim, evidence, and trace identifiers now exist, but the application needs a typed bundle that identifies what should be reviewed.
+
+Persistence and raw feedback capture are intentionally later concerns. This slice must not imply that a review report has been stored.
+
+## Decision
+
+Expose a read-only review-context contract containing:
+
+- the material claim ID, kind, value, and epistemic status;
+- the evidence IDs supporting the claim;
+- the execution-chain and node IDs;
+- a fixed set of allowed review reasons: wrong result, source issue, mapping issue, resolution issue, and stale result.
+
+The HTTP adapter exposes this as a preview at `/api/review-context?claim_id=...`. It returns references and review affordances, not user-authored feedback or a persisted report.
+
+## Consequences
+
+The future chat UI can start a review flow with complete reproducibility context. A later product-signal service may append the user's reason and detail to this context, subject to privacy and triage policy. Unknown claims fail closed with a not-found response.
+
+Adding review reasons or changing the context fields is a public contract change and requires corresponding tests and documentation updates.

--- a/docs/development/milestone-map.md
+++ b/docs/development/milestone-map.md
@@ -10,7 +10,7 @@ This is the canonical map from the current implementation to the architecture. M
 | M3 | Claims/evidence application service | Complete | `application/evidence_service.py` |
 | M4 | Constrained deterministic chat routing | Complete | `application/chat.py` |
 | M5 | Local HTTP chat/evidence inspector | Complete | [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82) |
-| M6 | Durable identifiers, source viewer, and review context | In progress | [Issues #85 and #87](https://github.com/stauntonjr/procurement-intelligence-lab/issues/87), ADR-013 |
+| M6 | Durable identifiers, source viewer, and review context | In progress | [Issues #85, #87, and #89](https://github.com/stauntonjr/procurement-intelligence-lab/issues/89), ADRs 013–014 |
 | M7 | Append-only persistence and temporal/as-of state | Planned | Ledger schema, migrations, rebuildable projections |
 | M8 | Retrieval projections and review UI | Planned | Labeled retrieval evaluation and review workflows |
 | M9 | Guarded actions, product signals, and integrated evaluation | Planned | Approval gates, sanitized feedback loop, release evidence |
@@ -32,6 +32,6 @@ The merged implementation sequence is:
 - M3: PR #80
 - M4: PR #81
 - M5: PR #82
-- M6: PR #86 for stable identifiers; source viewer in progress under Issue #87
+- M6: PR #86 for stable identifiers and PR #88 for source viewing; review context in progress under Issue #89
 
 This mapping is deliberately explicit so future agents do not infer milestone status from PR numbers or filenames.

--- a/src/procurement_intelligence_lab/application/review.py
+++ b/src/procurement_intelligence_lab/application/review.py
@@ -1,0 +1,53 @@
+"""Typed, non-persistent review context for evidence-backed claims."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from procurement_intelligence_lab.application.evidence_service import (
+    EvidenceBackedClaim,
+    inspect_bom_claims,
+)
+from procurement_intelligence_lab.domain.bom import Bom
+
+
+class ReviewReason(StrEnum):
+    WRONG_RESULT = "wrong_result"
+    SOURCE_ISSUE = "source_issue"
+    MAPPING_ISSUE = "mapping_issue"
+    RESOLUTION_ISSUE = "resolution_issue"
+    STALE_RESULT = "stale_result"
+
+
+@dataclass(frozen=True)
+class ReviewContext:
+    claim_id: str
+    claim_kind: str
+    claim_value: object
+    claim_status: str
+    evidence_ids: tuple[str, ...]
+    chain_id: str
+    node_ids: tuple[str, ...]
+    allowed_reasons: tuple[ReviewReason, ...]
+
+
+def review_context_for_claim(
+    claim_id: str, bom: Bom, canonical_candidates: tuple[str, ...]
+) -> ReviewContext:
+    claims = inspect_bom_claims(bom, canonical_candidates)
+    claim = next((claim for claim in claims if claim.claim_id == claim_id), None)
+    if claim is None:
+        raise LookupError(f"unknown claim ID: {claim_id}")
+    return _context_from_claim(claim)
+
+
+def _context_from_claim(claim: EvidenceBackedClaim) -> ReviewContext:
+    return ReviewContext(
+        claim_id=claim.claim_id,
+        claim_kind=claim.kind.value,
+        claim_value=claim.value,
+        claim_status=claim.status,
+        evidence_ids=tuple(ref.evidence_id for ref in claim.evidence),
+        chain_id=claim.execution_trace.chain_id,
+        node_ids=tuple(node.node_id for node in claim.execution_trace.nodes),
+        allowed_reasons=tuple(ReviewReason),
+    )

--- a/src/procurement_intelligence_lab/interfaces/web.py
+++ b/src/procurement_intelligence_lab/interfaces/web.py
@@ -13,6 +13,7 @@ from procurement_intelligence_lab.application.chat import (
     UnsupportedQuestionError,
     answer_question,
 )
+from procurement_intelligence_lab.application.review import review_context_for_claim
 
 _HTML = """<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
@@ -35,6 +36,10 @@ form.addEventListener("submit",async event=>{event.preventDefault();const q=new 
 
 class EvidenceNotFoundError(LookupError):
     """Raised when an evidence ID is not present in the committed fixture."""
+
+
+class ReviewContextNotFoundError(LookupError):
+    """Raised when a claim ID is not present in the committed fixture."""
 
 
 def _fixture() -> Path:
@@ -88,6 +93,31 @@ def source_payload(evidence_id: str) -> dict[str, object]:
     raise EvidenceNotFoundError(f"unknown evidence ID: {evidence_id}")
 
 
+def review_context_payload(claim_id: str) -> dict[str, object]:
+    bom = read_bom(_fixture())
+    try:
+        context = review_context_for_claim(
+            claim_id, bom, tuple(line.sku for line in bom.lines)
+        )
+    except LookupError as error:
+        raise ReviewContextNotFoundError(str(error)) from error
+    value = (
+        str(context.claim_value)
+        if isinstance(context.claim_value, Decimal)
+        else context.claim_value
+    )
+    return {
+        "claim_id": context.claim_id,
+        "claim_kind": context.claim_kind,
+        "claim_value": value,
+        "claim_status": context.claim_status,
+        "evidence_ids": context.evidence_ids,
+        "chain_id": context.chain_id,
+        "node_ids": context.node_ids,
+        "allowed_reasons": [reason.value for reason in context.allowed_reasons],
+    }
+
+
 class InspectorHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         parsed = urlparse(self.path)
@@ -110,6 +140,15 @@ class InspectorHandler(BaseHTTPRequestHandler):
                 body = json.dumps(source_payload(evidence_id)).encode()
                 self.send_response(200)
             except EvidenceNotFoundError as error:
+                body = json.dumps({"error": str(error)}).encode()
+                self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+        elif parsed.path == "/api/review-context":
+            claim_id = parse_qs(parsed.query).get("claim_id", [""])[0]
+            try:
+                body = json.dumps(review_context_payload(claim_id)).encode()
+                self.send_response(200)
+            except ReviewContextNotFoundError as error:
                 body = json.dumps({"error": str(error)}).encode()
                 self.send_response(404)
             self.send_header("Content-Type", "application/json")

--- a/src/procurement_intelligence_lab/interfaces/web.py
+++ b/src/procurement_intelligence_lab/interfaces/web.py
@@ -96,9 +96,7 @@ def source_payload(evidence_id: str) -> dict[str, object]:
 def review_context_payload(claim_id: str) -> dict[str, object]:
     bom = read_bom(_fixture())
     try:
-        context = review_context_for_claim(
-            claim_id, bom, tuple(line.sku for line in bom.lines)
-        )
+        context = review_context_for_claim(claim_id, bom, tuple(line.sku for line in bom.lines))
     except LookupError as error:
         raise ReviewContextNotFoundError(str(error)) from error
     value = (

--- a/tests/unit/test_review.py
+++ b/tests/unit/test_review.py
@@ -1,0 +1,35 @@
+from typing import cast
+
+import pytest
+
+from procurement_intelligence_lab.interfaces.web import (
+    ReviewContextNotFoundError,
+    claim_payload,
+    review_context_payload,
+)
+
+
+def test_review_context_preserves_claim_and_trace_references() -> None:
+    claim = claim_payload("How many GPUs are in the BOM?")
+    claim_id = cast(str, claim["claim_id"])
+
+    context = review_context_payload(claim_id)
+
+    assert context["claim_id"] == claim_id
+    assert context["claim_kind"] == "gpu_quantity"
+    assert context["claim_value"] == "4"
+    assert isinstance(context["chain_id"], str)
+    assert len(cast(tuple[str, ...], context["evidence_ids"])) == 1
+    assert len(cast(tuple[str, ...], context["node_ids"])) == 4
+    assert cast(list[str], context["allowed_reasons"]) == [
+        "wrong_result",
+        "source_issue",
+        "mapping_issue",
+        "resolution_issue",
+        "stale_result",
+    ]
+
+
+def test_review_context_rejects_unknown_claim_id() -> None:
+    with pytest.raises(ReviewContextNotFoundError):
+        review_context_payload("claim:missing")


### PR DESCRIPTION
## Summary

Add the next M6 slice: a typed, read-only review-context contract for claims and evidence.

## Milestone and issue

- Primary milestone: M6 Durable Identity, Source Viewer & Review Context
- Linked issue: #89
- Related issues: #85 and #87
- Acceptance evidence: review-context completeness and unknown-claim tests

## What changed

- Add typed review reasons for wrong results, source, mapping, resolution, and stale-result reports.
- Build review context from stable claim/evidence/trace identifiers.
- Expose `GET /api/review-context?claim_id=...`.
- Fail closed for unknown claim IDs.
- Add ADR-014 and update the milestone map.

## Architectural impact

This is a read-only preview contract. It does not persist feedback or accept user-authored report content yet. Persistence and product-signal capture remain later slices.

## Validation

CI should run formatting, lint, Pyright, and tests.