### PR TITLE
feat: establish append-only assertion ledger boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,24 @@ The showcase is a chat interface paired with an evidence inspector and source vi
 
 ## Architecture
 
-Artifacts flow through `StructuredDocument → MappedDocument → normalized observations → source assertions → entity mentions → resolution decisions → canonicalized assertions → reconciliation → operational state → derived intelligence`. Postgres is the intended canonical store; search, vector, and graph systems are replaceable projections. Core semantics are framework-independent Python dataclasses behind ports and adapters.
+Artifacts flow through StructuredDocument → MappedDocument → normalized observations → source assertions → entity mentions → resolution decisions → canonicalized assertions → reconciliation → operational state → derived intelligence. Postgres is the intended canonical store; search, vector, and graph systems are replaceable projections. Core semantics are framework-independent Python dataclasses behind ports and adapters.
 
 ## Status
 
-The initial vertical slice is complete: a dependency-free XLSX BOM adapter, typed line-level evidence, deterministic SKU/GPU/cost queries, explicit cost abstention, source assertions, conservative entity resolution, operational-state projection, reconciliation, and a framework-independent evidence chain.
+The initial evidence-first vertical slice is complete: a dependency-free XLSX BOM adapter, typed line-level evidence, deterministic SKU/GPU/cost queries, explicit cost abstention, source assertions, conservative entity resolution, operational-state projection, reconciliation, a claims/evidence service, constrained chat routing, and a local HTTP inspector with source lookup and reproducible review context.
 
-The current implementation also includes the claims/evidence service and a constrained chat adapter. A dependency-free local HTTP chat/evidence inspector is in progress in [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82). Durable identifiers, persistence, review workflows, retrieval projections, and product-feedback capture remain planned.
+M7 is now establishing the append-only assertion-ledger port and reference in-memory adapter. Durable database storage, temporal correction events, retrieval projections, and product-feedback persistence remain later slices.
 
-The canonical delivery map is [docs/development/milestone-map.md](docs/development/milestone-map.md). Changes to architecture or delivery status must follow the synchronization policy in [ADR-012](docs/adr/012-plan-and-milestone-synchronization.md).
+The canonical delivery map is docs/development/milestone-map.md. Changes to architecture or delivery status must follow the synchronization policy in ADR-012.
 
 ## Local entry points
 
-```bash
-uv sync --all-groups
-make check
-make eval
-make demo
-```
+    uv sync --all-groups
+    make check
+    make eval
+    make demo
 
-`make demo` is equivalent to `uv run python -m procurement_intelligence_lab`. Pass `--help` to inspect its synthetic-BOM and canonical-candidate inputs.
+make demo is equivalent to uv run python -m procurement_intelligence_lab. Pass --help to inspect its synthetic-BOM and canonical-candidate inputs.
 
 ## Public-data disclaimer
 

--- a/docs/adr/015-append-only-assertion-ledger.md
+++ b/docs/adr/015-append-only-assertion-ledger.md
@@ -1,0 +1,28 @@
+# ADR-015: Append-only assertion ledger behind a port
+
+Status: accepted
+
+## Context
+
+Source assertions are the preserved record of what an artifact said before entity resolution, reconciliation, or derived intelligence. The architecture requires canonical state to be a rebuildable projection of governed assertions, but the current lab has no persistence dependency.
+
+The next slice must establish the boundary without prematurely choosing Postgres schemas, an ORM, or a hosted service.
+
+## Decision
+
+Define an outbound `AssertionLedger` protocol for appending and reading source assertions. Each ledger entry has:
+
+- a stable assertion identifier;
+- a monotonically increasing sequence within the ledger;
+- an observation timestamp;
+- the immutable source assertion.
+
+The reference adapter is an in-memory append-only implementation. It supports ordered reads and inclusive as-of reads. It exposes no update or delete operation. Timestamps must be timezone-aware.
+
+A future durable adapter may use Postgres or another store, but it must preserve the append-only contract and rebuildable-projection semantics.
+
+## Consequences
+
+The semantic core and application services can depend on a small typed port while adapters own storage mechanics. Tests can validate temporal and ordering semantics without a database. The in-memory adapter is not a production durability claim; it is a contract reference and composition-root fixture.
+
+Schema design, migrations, correction events, retention, and transactional guarantees remain separate decisions for the durable adapter.

--- a/docs/development/github-plan.md
+++ b/docs/development/github-plan.md
@@ -21,9 +21,9 @@ The delivery sequence is intentionally vertical and may cross architectural laye
 - M2 Evidence Contract & Golden Tests — complete
 - M3 Claims / Evidence Application Service — complete
 - M4 Constrained Chat Routing — complete
-- M5 Local HTTP Chat Inspector — in progress
-- M6 Durable Identity, Source Viewer & Review Context — planned
-- M7 Append-Only Persistence & Temporal State — planned
+- M5 Local HTTP Chat Inspector — complete
+- M6 Durable Identity, Source Viewer & Review Context — complete
+- M7 Append-Only Persistence & Temporal State — in progress
 - M8 Retrieval Projections & Review UI — planned
 - M9 Guarded Actions, Product Signals & Evaluation — planned
 
@@ -41,10 +41,10 @@ Suggested labels are `area:architecture`, `area:domain`, `area:ingestion`, `area
 
 - Keep the semantic model and architecture invariants current.
 - Maintain the evidence inspector contract and UX drill-down chain.
-- Add stable identifiers before persistence or multi-document review.
+- Preserve stable identifiers across persistence adapters.
 - Define the synthetic data specification and evaluation manifests.
 - Prefer small vertical issues with explicit acceptance evidence over speculative issue floods.
 
 ## Runner security
 
-CI starts on GitHub-hosted runners. A future secure self-hosted DGX runner must be isolated, ephemeral or resettable, least-privilege, secret-free by default, and limited to trusted post-merge workflows. Untrusted public pull-request code is explicitly blocked from trusted self-hosted runners; public PRs use GitHub-hosted runners only.
+CI starts on GitHub-hosted runners. A future secure self-hosted DGX runner must be isolated, ephemeral or resettable, least-privilege, secret-free by default, and limited to trusted post-merge workflows. Untrusted public-pull-request code is explicitly blocked from trusted self-hosted runners; public PRs use GitHub-hosted runners only.

--- a/docs/development/milestone-map.md
+++ b/docs/development/milestone-map.md
@@ -10,8 +10,8 @@ This is the canonical map from the current implementation to the architecture. M
 | M3 | Claims/evidence application service | Complete | `application/evidence_service.py` |
 | M4 | Constrained deterministic chat routing | Complete | `application/chat.py` |
 | M5 | Local HTTP chat/evidence inspector | Complete | [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82) |
-| M6 | Durable identifiers, source viewer, and review context | In progress | [Issues #85, #87, and #89](https://github.com/stauntonjr/procurement-intelligence-lab/issues/89), ADRs 013–014 |
-| M7 | Append-only persistence and temporal/as-of state | Planned | Ledger schema, migrations, rebuildable projections |
+| M6 | Durable identifiers, source viewer, and review context | Complete | [PRs #86, #88, and #90](https://github.com/stauntonjr/procurement-intelligence-lab/pull/90), ADRs 013–014 |
+| M7 | Append-only persistence and temporal/as-of state | In progress | [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91), ADR-015 |
 | M8 | Retrieval projections and review UI | Planned | Labeled retrieval evaluation and review workflows |
 | M9 | Guarded actions, product signals, and integrated evaluation | Planned | Approval gates, sanitized feedback loop, release evidence |
 
@@ -32,6 +32,7 @@ The merged implementation sequence is:
 - M3: PR #80
 - M4: PR #81
 - M5: PR #82
-- M6: PR #86 for stable identifiers and PR #88 for source viewing; review context in progress under Issue #89
+- M6: PRs #86, #88, and #90
+- M7: Issue #91, implementation in progress
 
 This mapping is deliberately explicit so future agents do not infer milestone status from PR numbers or filenames.

--- a/src/procurement_intelligence_lab/adapters/memory_ledger.py
+++ b/src/procurement_intelligence_lab/adapters/memory_ledger.py
@@ -10,9 +10,7 @@ class InMemoryAssertionLedger:
     def __init__(self) -> None:
         self._entries: list[AssertionLedgerEntry] = []
 
-    def append(
-        self, assertion: SourceAssertion, *, observed_at: datetime
-    ) -> AssertionLedgerEntry:
+    def append(self, assertion: SourceAssertion, *, observed_at: datetime) -> AssertionLedgerEntry:
         if observed_at.tzinfo is None:
             raise ValueError("observed_at must be timezone-aware")
         entry = AssertionLedgerEntry(len(self._entries) + 1, assertion, observed_at)

--- a/src/procurement_intelligence_lab/adapters/memory_ledger.py
+++ b/src/procurement_intelligence_lab/adapters/memory_ledger.py
@@ -1,0 +1,28 @@
+"""In-memory append-only assertion ledger adapter."""
+
+from datetime import datetime
+
+from procurement_intelligence_lab.domain.assertions import SourceAssertion
+from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+
+
+class InMemoryAssertionLedger:
+    def __init__(self) -> None:
+        self._entries: list[AssertionLedgerEntry] = []
+
+    def append(
+        self, assertion: SourceAssertion, *, observed_at: datetime
+    ) -> AssertionLedgerEntry:
+        if observed_at.tzinfo is None:
+            raise ValueError("observed_at must be timezone-aware")
+        entry = AssertionLedgerEntry(len(self._entries) + 1, assertion, observed_at)
+        self._entries.append(entry)
+        return entry
+
+    def entries(self) -> tuple[AssertionLedgerEntry, ...]:
+        return tuple(self._entries)
+
+    def as_of(self, observed_at: datetime) -> tuple[AssertionLedgerEntry, ...]:
+        if observed_at.tzinfo is None:
+            raise ValueError("observed_at must be timezone-aware")
+        return tuple(entry for entry in self._entries if entry.observed_at <= observed_at)

--- a/src/procurement_intelligence_lab/domain/assertions.py
+++ b/src/procurement_intelligence_lab/domain/assertions.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from enum import StrEnum
 
 from procurement_intelligence_lab.domain.bom import Bom, EvidenceRef
+from procurement_intelligence_lab.domain.identity import stable_id
 
 
 class AssertionPredicate(StrEnum):
@@ -21,6 +22,17 @@ class SourceAssertion:
     value: str | Decimal
     evidence: EvidenceRef
     source_system: str = "document"
+
+    @property
+    def assertion_id(self) -> str:
+        return stable_id(
+            "assertion",
+            self.subject_key,
+            self.predicate.value,
+            str(self.value),
+            self.evidence.evidence_id,
+            self.source_system,
+        )
 
 
 def assertions_for_bom_line(

--- a/src/procurement_intelligence_lab/domain/ledger.py
+++ b/src/procurement_intelligence_lab/domain/ledger.py
@@ -1,0 +1,23 @@
+"""Append-only source assertion ledger records."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from procurement_intelligence_lab.domain.assertions import SourceAssertion
+from procurement_intelligence_lab.domain.identity import stable_id
+
+
+@dataclass(frozen=True)
+class AssertionLedgerEntry:
+    sequence: int
+    assertion: SourceAssertion
+    observed_at: datetime
+
+    @property
+    def entry_id(self) -> str:
+        return stable_id(
+            "assertion-entry",
+            self.sequence,
+            self.assertion.assertion_id,
+            self.observed_at.isoformat(),
+        )

--- a/src/procurement_intelligence_lab/ports/assertion_ledger.py
+++ b/src/procurement_intelligence_lab/ports/assertion_ledger.py
@@ -1,0 +1,19 @@
+"""Outbound persistence ports."""
+
+from datetime import datetime
+from typing import Protocol
+
+from procurement_intelligence_lab.domain.assertions import SourceAssertion
+from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+
+
+class AssertionLedger(Protocol):
+    """Append-only storage contract for source assertions."""
+
+    def append(
+        self, assertion: SourceAssertion, *, observed_at: datetime
+    ) -> AssertionLedgerEntry: ...
+
+    def entries(self) -> tuple[AssertionLedgerEntry, ...]: ...
+
+    def as_of(self, observed_at: datetime) -> tuple[AssertionLedgerEntry, ...]: ...

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 
 import pytest
@@ -23,8 +23,8 @@ def test_assertion_ids_are_stable() -> None:
 
 def test_in_memory_ledger_is_append_only_and_ordered() -> None:
     ledger = InMemoryAssertionLedger()
-    first_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    second_time = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    first_time = datetime(2026, 1, 1, tzinfo=UTC)
+    second_time = datetime(2026, 1, 2, tzinfo=UTC)
 
     first = ledger.append(_assertion("4"), observed_at=first_time)
     second = ledger.append(_assertion("8"), observed_at=second_time)
@@ -39,4 +39,4 @@ def test_ledger_requires_timezone_aware_timestamps() -> None:
     ledger = InMemoryAssertionLedger()
 
     with pytest.raises(ValueError, match="timezone-aware"):
-        ledger.append(_assertion("4"), observed_at=datetime(2026, 1, 1))
+        ledger.append(_assertion("4"), observed_at=datetime(2026, 1, 1))  # noqa: DTZ001

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from procurement_intelligence_lab.adapters.memory_ledger import InMemoryAssertionLedger
+from procurement_intelligence_lab.domain.assertions import (
+    AssertionPredicate,
+    SourceAssertion,
+)
+from procurement_intelligence_lab.domain.bom import EvidenceRef
+
+
+def _assertion(quantity: str) -> SourceAssertion:
+    evidence = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B"))
+    return SourceAssertion("GPU-A", AssertionPredicate.HAS_QUANTITY, Decimal(quantity), evidence)
+
+
+def test_assertion_ids_are_stable() -> None:
+    assert _assertion("4").assertion_id == _assertion("4").assertion_id
+    assert _assertion("4").assertion_id != _assertion("8").assertion_id
+
+
+def test_in_memory_ledger_is_append_only_and_ordered() -> None:
+    ledger = InMemoryAssertionLedger()
+    first_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    second_time = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+    first = ledger.append(_assertion("4"), observed_at=first_time)
+    second = ledger.append(_assertion("8"), observed_at=second_time)
+
+    assert [entry.sequence for entry in ledger.entries()] == [1, 2]
+    assert first.entry_id != second.entry_id
+    assert ledger.as_of(first_time) == (first,)
+    assert ledger.as_of(second_time) == (first, second)
+
+
+def test_ledger_requires_timezone_aware_timestamps() -> None:
+    ledger = InMemoryAssertionLedger()
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        ledger.append(_assertion("4"), observed_at=datetime(2026, 1, 1))


### PR DESCRIPTION
## Summary

Begin M7 by defining the append-only assertion-ledger boundary and a dependency-free in-memory reference adapter.

## Milestone and issue

- Primary milestone: M7 Append-Only Persistence & Temporal State
- Linked issue: #91
- Acceptance evidence: stable assertion IDs, append ordering, timezone-aware timestamps, and as-of reads

## What changed

- Add stable `SourceAssertion.assertion_id`.
- Add immutable `AssertionLedgerEntry` with sequence and observation timestamp.
- Add the `AssertionLedger` Protocol.
- Add `InMemoryAssertionLedger` with ordered and inclusive as-of reads.
- Add ADR-015 defining the persistence boundary.
- Mark M6 complete and M7 in progress in the milestone map and README.

## Architectural impact

The semantic core remains database-independent. Postgres remains a future adapter choice; this PR establishes behavior and dependency-injection seams without claiming production durability.

## Validation

CI should run formatting, lint, Pyright, and tests.