### PR TITLE
ci: add layered PR review governance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,18 @@
+# Copilot code review guidance
+
+When reviewing pull requests in this repository:
+
+- Read `AGENTS.md` and the relevant architecture/domain documentation before judging design choices.
+- Prioritize correctness, security, provenance, architectural boundaries, and acceptance criteria over style comments already enforced by Ruff/Pyright/pytest.
+- Enforce the principle: **core owns semantics; adapters own mechanics; models produce evidence; policies produce decisions**.
+- Flag external framework, persistence, model-provider, or transport types leaking into domain semantics.
+- Flag authoritative arithmetic, reconciliation, identity decisions, permissions, or side effects being delegated to unconstrained LLM output when deterministic code or policy should own them.
+- Flag material user-facing claims that cannot be traced through typed evidence/provenance.
+- For entity resolution, treat false merges as more severe than unresolved identities; nearest-neighbor similarity alone is not identity.
+- For document intelligence, distinguish document structuring quality from semantic/schema mapping quality.
+- For model, prompt, retrieval, extraction, entity-resolution, or ranking changes, require benchmark/evaluation evidence against a named baseline when the PR claims quality improvement.
+- Review dependency additions skeptically: implementation packages should remain behind ports/adapters and must not reshape core contracts merely for convenience.
+- For application-agent write paths, verify authorization, project/tenant scope, approval policy, idempotency, auditability, and resistance to untrusted model/tool input.
+- Do not expose or recommend committing confidential, proprietary, tenant, interview-confidential, or operational procurement data.
+- Prefer a few high-confidence, actionable findings with exact file/line context over broad stylistic commentary.
+- Do not approve architecture changes that require an ADR unless the ADR is present and the consequences/revisit criteria are documented.

--- a/.github/instructions/agents.instructions.md
+++ b/.github/instructions/agents.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "src/procurement_intelligence_lab/**/agents/**/*.py,src/procurement_intelligence_lab/**/actions/**/*.py,src/procurement_intelligence_lab/interfaces/mcp/**/*.py"
+---
+
+# Operational-agent review rules
+
+- Agent-framework state is execution state, never canonical procurement/business state.
+- Agent tools should expose semantic application capabilities rather than arbitrary SQL, Cypher, shell, or unrestricted code execution.
+- Reads and writes must be distinguishable; consequential writes require explicit authorization and approval policy.
+- Verify tenant/project scope on every relevant operation and do not rely on the model to remember access filters.
+- Side effects must be idempotent where retries are possible and must emit auditable records.
+- Treat tool/model inputs as untrusted. Check prompt/tool injection boundaries and avoid passing retrieved text into privileged instructions without controls.
+- LLMs may interpret, plan, and synthesize; deterministic code/policy should own arithmetic, permissions, state transitions, thresholds, and irreversible effects.
+- Material claims returned to users need typed evidence references and epistemic status.

--- a/.github/instructions/domain.instructions.md
+++ b/.github/instructions/domain.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "src/procurement_intelligence_lab/domain/**/*.py"
+---
+
+# Domain review rules
+
+- Domain code must remain framework-independent and should prefer stdlib types/dataclasses plus project-owned value objects.
+- Do not import Docling, SQLAlchemy, FastMCP, LangChain/LangGraph, Pydantic, cloud SDKs, model SDKs, or transport clients into the domain layer.
+- Intrinsic invariants, calculations, derived properties, and transformations may live on domain objects when strongly coupled to the object.
+- Behavior requiring repositories, external services, orchestration, authorization, or cross-aggregate coordination belongs outside domain objects.
+- Preserve semantic distinctions among source assertions, entity-resolution decisions, reconciled state, derived facts, predictions, decisions, and actions.
+- Do not collapse unresolved source mentions into canonical identity without an auditable resolution decision.
+- Money/quantities must not use binary floating point for authoritative values.

--- a/.github/instructions/evals.instructions.md
+++ b/.github/instructions/evals.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "evals/**/*,docs/evaluation/**/*,src/procurement_intelligence_lab/evaluation/**/*.py,tests/regression/**/*"
+---
+
+# Evaluation review rules
+
+- A quality-improvement claim must identify the baseline, candidate configuration, dataset/version, metrics, and reproducible run context.
+- Separate candidate-generation recall from pair-scoring/decision quality in entity-resolution evaluation.
+- Report false merges explicitly; prefer unresolved identity over an unjustified merge.
+- Separate document-structuring metrics from schema-mapping/extraction metrics so failures can be localized.
+- Retrieval changes should report task-appropriate ranking/relevance metrics and inspect error cases, not only aggregate scores.
+- LLM/prompt/program changes require task-success or correctness metrics; subjective prompt readability is not evidence of improvement.
+- Preserve run metadata such as git SHA, schema/config/model/prompt versions, dataset version, and seed when meaningful.
+- Do not silently tune on the held-out evaluation set.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: code-review
+description: Review pull requests for correctness, architecture invariants, provenance, security boundaries, and repository acceptance criteria. Use for PR code review.
+---
+
+# Pull request code review
+
+1. Read `AGENTS.md`, the PR description, changed files, and relevant ADRs.
+2. Determine the semantic surface changed: domain, application, port, adapter, interface, persistence, intelligence/eval, or operational agent.
+3. Verify dependency direction and explicit DI/composition-root conventions. Flag infrastructure/framework construction inside domain/application services.
+4. Verify the semantic pipeline remains explicit: structure -> mapping -> normalization -> source assertions -> entity resolution -> canonicalized assertions -> reconciliation -> operational state -> derived intelligence.
+5. Check provenance. Material user-facing claims should retain machine-readable evidence paths to source evidence and implementation versions.
+6. Check probabilistic/deterministic boundaries. Models may produce evidence or proposals; deterministic policies should own authoritative calculations, permissions, state transitions, and consequential decisions where practical.
+7. Inspect failure handling: retryable, non-retryable, and human-review outcomes must not be conflated.
+8. Check tests/evals against the PR's acceptance criteria. If the PR claims intelligence-quality improvement, use the evaluation-review skill criteria.
+9. Check security and sensitive-data handling, especially for public-repository fixtures and agent/tool changes.
+10. Report only actionable findings. Distinguish blocking correctness/security/invariant findings from optional design suggestions. Avoid duplicating formatter/linter output.

--- a/.github/skills/evaluation-review/SKILL.md
+++ b/.github/skills/evaluation-review/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: evaluation-review
+description: Review PRs that claim improvements to extraction, entity resolution, retrieval, ranking, prompts, models, forecasts, or agents. Verify benchmark evidence and regression risk.
+---
+
+# Evaluation review
+
+For any PR that changes an intelligent or probabilistic component:
+
+1. Identify the claimed improvement and the current baseline.
+2. Verify the evaluation corpus and version are named and representative of the claim.
+3. Verify the candidate run records git SHA, configuration, model/prompt/schema versions, and seed where meaningful.
+4. Check task-specific metrics and important asymmetric errors:
+   - document structuring: OCR/text, table/cell/row-column reconstruction, reading order as applicable;
+   - schema mapping: field accuracy/F1 and row grouping separately from structure quality;
+   - entity resolution: candidate recall, pair/decision precision-recall, false merges, review rate, calibration where relevant;
+   - retrieval/reranking: Recall@K, MRR/nDCG or task-appropriate metrics plus error inspection;
+   - agents: tool-selection/task success, evidence support, abstention, authorization/action correctness;
+   - forecasts: discrimination/calibration/error intervals and temporal leakage checks as appropriate.
+5. Confirm the PR does not improve one headline metric by causing an unacceptable regression elsewhere (latency, cost, precision, false merges, safety, or review load).
+6. Require representative error examples or an error-analysis artifact for material algorithm changes.
+7. Do not accept “prompt is clearer,” “model is newer,” or “framework is popular” as quality evidence.
+8. If evidence is incomplete, recommend an experiment rather than an architectural commitment.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "23 9 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+
+jobs:
+  analyze:
+    name: CodeQL (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:python

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,7 +45,6 @@ jobs:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           use_vertex_ai: 'false'
           use_gemini_code_assist: 'false'
-          upload_artifacts: 'false'
           settings: |-
             {
               "maxSessionTurns": 20,
@@ -77,11 +76,11 @@ jobs:
             review format specified by GEMINI.md.
 
       - name: Post Gemini review
-        if: steps.gemini.outputs.summary != ''
+        if: steps.gemini.outputs.gemini_response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GEMINI_REVIEW: ${{ steps.gemini.outputs.summary }}
+          GEMINI_REVIEW: ${{ steps.gemini.outputs.gemini_response }}
         run: |
           set -euo pipefail
           printf '%s\n' "$GEMINI_REVIEW" > /tmp/gemini-review.md

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,0 +1,88 @@
+name: Gemini PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: gemini-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    # Repository secrets are never exposed to fork PRs. Keep this reviewer to
+    # trusted same-repository branches and do not run it for Dependabot.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run Gemini advisory review
+        id: gemini
+        continue-on-error: true
+        uses: google-github-actions/run-gemini-cli@a3bf79042542528e91937b3a3a6fbc4967ee3c31 # patched v0 line
+        env:
+          # Deliberately withhold GitHub credentials from the model. A later,
+          # deterministic step is the only component allowed to post a review.
+          GITHUB_TOKEN: ''
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          use_vertex_ai: 'false'
+          use_gemini_code_assist: 'false'
+          upload_artifacts: 'false'
+          settings: |-
+            {
+              "maxSessionTurns": 20,
+              "telemetry": {"enabled": false},
+              "tools": {
+                "core": [
+                  "read_file",
+                  "run_shell_command(git)"
+                ]
+              }
+            }
+          prompt: |-
+            You are the independent advisory PR reviewer described in GEMINI.md.
+            Read GEMINI.md and AGENTS.md before reviewing.
+
+            Review pull request #${{ github.event.pull_request.number }}:
+            ${{ github.event.pull_request.title }}
+
+            Base SHA: ${{ github.event.pull_request.base.sha }}
+            Head SHA: ${{ github.event.pull_request.head.sha }}
+
+            Inspect the complete change with:
+              git diff --find-renames ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+
+            Read relevant changed files and repository guidance as needed. Focus
+            on correctness, edge cases, security/privacy, tests/evals, architectural
+            boundary violations, and evidence/provenance loss. Do not perform any
+            mutation or external side effect. Return only the concise Markdown
+            review format specified by GEMINI.md.
+
+      - name: Post Gemini review
+        if: steps.gemini.outputs.summary != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GEMINI_REVIEW: ${{ steps.gemini.outputs.summary }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$GEMINI_REVIEW" > /tmp/gemini-review.md
+          gh pr review "$PR_NUMBER" --comment --body-file /tmp/gemini-review.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 *.egg-info/
 .DS_Store
 
+# Gemini CLI local state / credentials
+.gemini/
+gha-creds-*.json

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,58 @@
+# Gemini Review Guidance
+
+You are an advisory pull-request reviewer for Procurement Intelligence Lab.
+
+Read `AGENTS.md` first, then relevant architecture, ADR, evaluation, and path-specific documentation before judging a change. Review the actual diff rather than restating the pull-request description.
+
+## Independent-review remit
+
+Gemini is intentionally a second opinion alongside Copilot. Prioritize findings that are easy for a general reviewer to miss:
+
+- correctness defects and edge cases
+- unsafe assumptions, missing error handling, and concurrency/resource-lifecycle issues
+- test gaps and weak assertions
+- security and privacy smells
+- maintainability problems that materially increase future change risk
+- mismatches between implementation and documented acceptance criteria
+- provenance/evidence loss
+- accidental nondeterminism in authoritative calculations or state transitions
+
+Do not spend review budget on formatting, import ordering, or style already enforced by Ruff/Pyright/pytest.
+
+## Architectural rules
+
+Preserve these invariants:
+
+- Core owns semantics; adapters own mechanics.
+- Models produce evidence; policies produce decisions.
+- Domain code remains framework-independent.
+- External libraries and services stay behind ports/adapters.
+- Source assertions are claims, not canonical truth.
+- Entity resolution occurs after source assertions and before reconciliation into operational state.
+- Reconciliation is deterministic and explainable wherever practical.
+- Material user-facing claims preserve machine-readable provenance to source evidence.
+- Search/vector/graph stores are projections or indexes, not independent truth stores.
+- Agent-framework state is execution state, not business state.
+- Operational writes require authorization, auditability, and explicit policy boundaries.
+
+## Intelligence changes
+
+For extraction, ER, retrieval, ranking, prompting, or model changes, require evidence appropriate to the claim. In particular:
+
+- document structuring and semantic schema mapping are separate evaluation stages
+- ER false merges are more costly than unresolved matches
+- prompt/model improvements require baseline-vs-candidate evaluation, not subjective wording claims
+- do not equate vector similarity with entity identity
+- confidence values from different stages are not interchangeable
+
+## Review output
+
+Return concise Markdown suitable for a PR comment:
+
+1. `## Gemini review`
+2. Findings ordered by severity (`Critical`, `High`, `Medium`, `Low`)
+3. For each finding: affected path/area, why it matters, and a concrete corrective direction
+4. `## Test/eval gaps` only when there are meaningful gaps
+5. `## Verdict` with one of: `No material issues found`, `Advisory changes recommended`, or `Material issue found`
+
+Do not approve, merge, request changes, push commits, edit issues, or invoke external side effects. This reviewer is advisory only.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ check:
 	uv run ruff check .
 	uv run pyright
 	uv run pytest
-	@uv run python -c "from pathlib import Path; required=['AGENTS.md','README.md','docs/architecture/overview.md','docs/domain/semantic-model.md','docs/architecture/evidence-and-ux.md']; missing=[p for p in required if not Path(p).exists()]; print(f'missing: {missing}' if missing else 'architecture checks passed'); raise SystemExit(1 if missing else 0)"
+	uv run python tools/check_architecture.py
+	@uv run python -c "from pathlib import Path; required=['AGENTS.md','README.md','docs/architecture/overview.md','docs/domain/semantic-model.md','docs/architecture/evidence-and-ux.md']; missing=[p for p in required if not Path(p).exists()]; print(f'missing: {missing}' if missing else 'architecture document checks passed'); raise SystemExit(1 if missing else 0)"
 eval:
 	@echo 'M0 evaluation harness is scaffolded; benchmark manifests are not yet populated.'
 demo:

--- a/docs/development/code-review.md
+++ b/docs/development/code-review.md
@@ -1,0 +1,65 @@
+# Pull request review governance
+
+## Principle
+
+Use deterministic systems to enforce known invariants and AI reviewers to surface judgment-heavy risks. Do not make merge safety depend on an LLM reviewer agreeing with a change.
+
+## Review layers
+
+### Required or candidate-for-required deterministic checks
+
+- `CI / checks`: Ruff formatting/lint, Pyright, pytest, documentation-presence checks, and deterministic architecture import checks.
+- `CodeQL (Python)`: semantic security scanning using GitHub CodeQL with the `security-extended` query suite.
+- `Dependency Review`: reject newly introduced dependencies with known `high` or `critical` vulnerabilities. Dependency additions still require architectural justification even when vulnerability-free.
+
+Repository branch/ruleset settings should make deterministic checks required only after they have demonstrated a low false-positive rate. Security findings should be evaluated at the finding level; do not weaken checks merely to obtain a green build.
+
+### Advisory AI review
+
+GitHub Copilot code review is the default general AI reviewer. It is guided by:
+
+- `AGENTS.md` for cross-agent repository rules;
+- `.github/copilot-instructions.md` for always-on review priorities;
+- `.github/instructions/*.instructions.md` for path-specific rules;
+- `.github/skills/code-review/` for architecture/provenance review procedure;
+- `.github/skills/evaluation-review/` for ML/LLM/intelligence quality claims.
+
+AI review is advisory. High-confidence findings should be resolved or explicitly rebutted, but Copilot approval is not a merge invariant.
+
+## Review responsibilities
+
+### General code review
+
+Focus on correctness, maintainability, typed failure behavior, dependency direction, and whether the implementation satisfies the Issue/PR acceptance criteria. Avoid duplicating formatter/linter output.
+
+### Architecture Guardian
+
+Architecture is partly deterministic and partly judgment-based.
+
+Deterministic checks currently enforce that the framework-independent `domain/` package imports only standard-library or project-owned modules. Additional rules should migrate into deterministic checks only when they can be expressed with low ambiguity.
+
+AI review additionally checks semantic leakage such as infrastructure objects defining domain concepts, models directly deciding canonical state, or an adapter-specific representation escaping its boundary.
+
+### Evaluation Reviewer
+
+PRs claiming extraction, entity-resolution, retrieval, reranking, prompt/model, forecasting, or agent-quality improvements must include reproducible evidence against a baseline. See `.github/skills/evaluation-review/SKILL.md` and `docs/evaluation/`.
+
+### Security and agent safety
+
+CodeQL covers code-level vulnerability classes. Operational-agent code additionally requires review of authorization, tenant/project scope, tool privilege, prompt/tool-injection boundaries, approval policy, idempotency, and auditability. These are path-specific Copilot review concerns until deterministic policy checks become practical.
+
+### Provenance review
+
+As the evidence architecture matures, material user-facing claims must remain traceable through machine-readable evidence references to deterministic computations/state, reconciliation and resolution decisions, source assertions, structured source elements, and original artifacts. Provenance review should become increasingly machine-enforceable over time.
+
+## Automatic Copilot review setting
+
+Repository administrators should enable automatic GitHub Copilot code review for pull requests and, if useful, re-review on new pushes. This is a repository/ruleset setting rather than a workflow file. Keep Copilot advisory; required merge gates should remain deterministic.
+
+## Runner security
+
+All PR review workflows run on GitHub-hosted runners. Future trusted self-hosted/GPU runners must not execute arbitrary code from untrusted public pull requests. Expensive or trusted-machine evaluations should be triggered only through reviewed/authorized paths.
+
+## Adding another reviewer
+
+Do not add another generic AI review bot merely for coverage. A new reviewer must have a distinct responsibility, measurable benefit, and low overlap with existing checks. Prefer enhancing repository-specific Copilot instructions/skills or adding deterministic checks before adding another bot.

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -30,9 +30,7 @@ def main() -> int:
 
     for path in sorted(DOMAIN.rglob("*.py")):
         for module in sorted(imported_roots(path) - allowed):
-            violations.append(
-                f"{path.relative_to(ROOT)} imports third-party module {module!r}"
-            )
+            violations.append(f"{path.relative_to(ROOT)} imports third-party module {module!r}")
 
     if violations:
         print("Architecture boundary violations:")

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -1,0 +1,48 @@
+"""Deterministic architecture checks used by local and CI validation."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOMAIN = ROOT / "src" / "procurement_intelligence_lab" / "domain"
+PROJECT_ROOT = "procurement_intelligence_lab"
+
+
+def imported_roots(path: Path) -> set[str]:
+    """Return top-level modules imported by a Python source file."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            roots.add(node.module.split(".", 1)[0])
+    return roots
+
+
+def main() -> int:
+    """Fail when the framework-independent domain imports third-party packages."""
+    violations: list[str] = []
+    allowed = set(sys.stdlib_module_names) | {PROJECT_ROOT}
+
+    for path in sorted(DOMAIN.rglob("*.py")):
+        for module in sorted(imported_roots(path) - allowed):
+            violations.append(
+                f"{path.relative_to(ROOT)} imports third-party module {module!r}"
+            )
+
+    if violations:
+        print("Architecture boundary violations:")
+        for violation in violations:
+            print(f"- {violation}")
+        return 1
+
+    print("architecture import checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- Add repository-wide Copilot code-review instructions tailored to the architecture and evidence model.
- Add path-specific review instructions for domain code, operational agents/actions, and evaluation code.
- Add Copilot `code-review` and `evaluation-review` agent skills.
- Add CodeQL security scanning for Python with the `security-extended` suite.
- Add GitHub Dependency Review for PR dependency changes, failing on high/critical known vulnerabilities.
- Add a deterministic AST-based architecture check that prevents third-party imports from leaking into the framework-independent domain package, and run it from `make check`.
- Add an independent Gemini advisory reviewer using the repository `GEMINI_API_KEY` secret and Google's official `run-gemini-cli` action.
- Add `GEMINI.md` with a deliberately different review remit: correctness, edge cases, security/privacy, test/eval gaps, maintainability, and provenance loss.
- Document the review governance model and runner-security policy.

## Review model

- **Deterministic gates:** CI, architecture checks, CodeQL, dependency review.
- **Advisory AI review:** GitHub Copilot plus Gemini as an independent second opinion.
- **Later targeted review:** provenance and operational-agent safety become more machine-enforceable as those surfaces mature.

## Gemini security model

- Gemini runs only for trusted same-repository PR branches, never fork PRs or Dependabot PRs.
- The Gemini action is pinned to a patched action commit after Google's April 2026 workspace-trust security update.
- The model receives **no `GITHUB_TOKEN`**. It gets read-only local tools (`read_file` and `git`) only.
- A separate deterministic shell step posts Gemini's returned summary as a COMMENT review using GitHub's ephemeral token.
- Gemini is `continue-on-error` so free-tier quota/rate-limit failures cannot block merges.

## Important boundary

AI reviewers do not own merge correctness. Known invariants should migrate into deterministic checks when they can be enforced with low ambiguity.

## Manual repository settings

- Automatic Copilot code review itself is configured in GitHub repository/ruleset settings rather than by workflow YAML. After this PR lands, enable automatic Copilot review (and optionally review-on-new-push); the instructions and skills in this PR will shape those reviews.
- GitHub Dependency Review requires the repository **Dependency graph** to be enabled under repository security settings. The workflow intentionally remains failing until that prerequisite is enabled rather than silently weakening the gate.

## Security

All workflows use GitHub-hosted runners. No public-PR workflow is permitted to dispatch arbitrary code to future trusted self-hosted/GPU runners.