### PR TITLE
docs: establish canonical shared project memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,5 +10,12 @@
 - Never add confidential or proprietary data.
 - Development agents and operational agents are distinct and must not share authority implicitly.
 
-Issues are executable specifications. Every change must preserve provenance, typed failure boundaries, and the evidence contract. Read this file, relevant skills, and ADRs before changing architecture.
+## Shared project memory
 
+Repository artifacts are the canonical shared engineering memory across ChatGPT, Work, Codex, humans, and other development agents. Conversational history is exploratory, transient, and non-authoritative.
+
+A fresh agent must read `AGENTS.md`, [`docs/project/handoff.md`](docs/project/handoff.md), the relevant GitHub Issue, and linked ADRs/docs before making changes. Material architectural or product decisions discovered in chats must be written back to durable repository artifacts. PRs that materially change project state should update the handoff index when appropriate.
+
+Chat/Work is for exploration and planning. Codex and other development agents implement against the repository. GitHub docs, Issues, ADRs, and PRs are the durable shared state; do not persist hidden chain-of-thought or entire chat transcripts.
+
+Issues are executable specifications. Every change must preserve provenance, typed failure boundaries, and the evidence contract. Read this file, relevant skills, and ADRs before changing architecture.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ check:
 	uv run ruff check .
 	uv run pyright
 	uv run pytest
-	@uv run python -c "from pathlib import Path; required=['AGENTS.md','README.md','docs/architecture/overview.md','docs/domain/semantic-model.md','docs/architecture/evidence-and-ux.md']; missing=[p for p in required if not Path(p).exists()]; print(f'missing: {missing}' if missing else 'architecture checks passed'); raise SystemExit(1 if missing else 0)"
+	@uv run python -c "from pathlib import Path; required=['AGENTS.md','README.md','docs/project/handoff.md','docs/architecture/overview.md','docs/domain/semantic-model.md','docs/architecture/evidence-and-ux.md']; missing=[p for p in required if not Path(p).exists()]; print(f'missing: {missing}' if missing else 'architecture checks passed'); raise SystemExit(1 if missing else 0)"
 eval:
 	@echo 'M0 evaluation harness is scaffolded; benchmark manifests are not yet populated.'
 demo:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The showcase is a chat interface paired with an evidence inspector and source vi
 
 Artifacts flow through StructuredDocument → MappedDocument → normalized observations → source assertions → entity mentions → resolution decisions → canonicalized assertions → reconciliation → operational state → derived intelligence. Postgres is the intended canonical store; search, vector, and graph systems are replaceable projections. Core semantics are framework-independent Python dataclasses behind ports and adapters.
 
-## Status
+## Project memory and status
+
+The repository is the canonical interoperability layer across ChatGPT, Work, Codex, humans, and other development agents. Use [docs/project/handoff.md](docs/project/handoff.md) as the concise fresh-agent index, then follow its links to the authoritative milestone map, ADRs, architecture docs, Issues, and PRs. Chat/Work supports exploration and planning; development agents implement against the repo; GitHub artifacts carry durable shared state.
 
 The initial evidence-first vertical slice is complete: a dependency-free XLSX BOM adapter, typed line-level evidence, deterministic SKU/GPU/cost queries, explicit cost abstention, source assertions, conservative entity resolution, operational-state projection, reconciliation, a claims/evidence service, constrained chat routing, and a local HTTP inspector with source lookup and reproducible review context.
 

--- a/docs/project/handoff.md
+++ b/docs/project/handoff.md
@@ -1,0 +1,65 @@
+# Project handoff
+
+## Purpose and use
+
+This page is a concise orientation index for a fresh human or development agent. It explains where the current state is recorded and what to read first; it is not a transcript, decision log, or duplicate architecture specification.
+
+Start with [AGENTS.md](../../AGENTS.md), then read the relevant [GitHub Issue](https://github.com/stauntonjr/procurement-intelligence-lab/issues), linked ADRs, and the authoritative documents below before changing the repository.
+
+## Current milestone and status
+
+- **M7 — Append-only persistence and temporal/as-of state:** in progress. See the [canonical milestone map](../development/milestone-map.md), [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91), and [ADR-015](../adr/ADR-015.md).
+- **M8 — Retrieval projections and review UI:** planned.
+- **M9 — Guarded actions, product signals, and integrated evaluation:** planned.
+- The initial M0–M6 evidence-first vertical slice is complete on `main`; the [root README](../../README.md) records the current product boundary and runnable entry points.
+
+## Current architecture
+
+The system preserves evidence from synthetic/semi-structured procurement documents through structured mapping, source assertions, entity mentions, resolution decisions, canonicalized assertions, reconciliation, operational state, and derived intelligence. Core semantics remain framework-independent; adapters own external mechanics. Postgres is the intended canonical store, while lexical, vector, and graph systems are replaceable projections. Deterministic services compute and enforce policy; AI-assisted interfaces explain and route work. See [architecture overview](../architecture/overview.md), [semantic model](../domain/semantic-model.md), and [architecture tradeoffs](../architecture.md).
+
+## Recently completed
+
+- M0–M4 repository, evidence, claims, and constrained chat foundations.
+- M5 local HTTP chat/evidence inspector; see [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82).
+- M6 durable identifiers, source viewer, and review context; see [PRs #86, #88, and #90](https://github.com/stauntonjr/procurement-intelligence-lab/pull/90).
+- Initial procurement query contracts and public-dataset planning; see [draft PR #76](https://github.com/stauntonjr/procurement-intelligence-lab/pull/76).
+
+## Active work and PRs
+
+- [PR #94](https://github.com/stauntonjr/procurement-intelligence-lab/pull/94) implements the M7.1 anomaly taxonomy and provenance boundary.
+- [PR #95](https://github.com/stauntonjr/procurement-intelligence-lab/pull/95) fixes the related anomaly-test constructor failure.
+- [PR #93](https://github.com/stauntonjr/procurement-intelligence-lab/pull/93) adds layered PR review governance.
+- [PR #84](https://github.com/stauntonjr/procurement-intelligence-lab/pull/84) documents agent-framework evaluation strategy.
+- M6 follow-on work is tracked by [Issues #85, #87, and #89](https://github.com/stauntonjr/procurement-intelligence-lab/issues/89).
+
+## Settled decisions
+
+- Preserve provenance and source assertions; do not turn extraction or similarity into truth.
+- Keep domain semantics framework- and database-independent, with explicit ports, adapters, dependency injection, and a visible composition root.
+- Prefer deterministic computation and policy enforcement; AI systems may interpret, explain, or route but do not silently bypass contracts.
+- Keep development agents and operational agents distinct; external actions require authorization, approval, idempotency, and audit.
+- Use synthetic or demonstrably public data only. This is an architectural lab, not a production procurement authority.
+- Follow the repository constitution and ADRs for architecture changes; use benchmark evidence for model or algorithm swaps.
+
+## Open decisions and questions
+
+- Which append-only persistence/database adapter should follow the M7 port, and what temporal correction evidence is required? Start with [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91) and ADR-015.
+- Which retrieval projections and fusion strategy earn adoption under the M8 evaluation plan? Start with [Issues #54, #55, #57, and #59](https://github.com/stauntonjr/procurement-intelligence-lab/issues/59).
+- Which review, guarded-action, and product-feedback slices should be sequenced next? Use the [milestone map](../development/milestone-map.md) and linked issue acceptance criteria.
+
+## Recommended next work
+
+1. Review and merge the active M7/related governance PRs only after their checks and acceptance evidence are current.
+2. Continue M7 from Issue #91 and ADR-015; preserve append-only and temporal semantics.
+3. Record any changed milestone/status mapping in the milestone map and update this index when the change materially affects onboarding.
+4. Before selecting retrieval or agent frameworks, run the repository's stated evaluation and benchmark work.
+
+## Refresh protocol
+
+Treat this page as a concise index, not a second source of truth. On each meaningful change:
+
+1. Read the relevant code, tests, ADRs, architecture docs, and GitHub Issue/PR.
+2. Update this page only when the milestone, active work, settled decisions, or recommended next work changes materially.
+3. Link to authoritative artifacts instead of copying their full content.
+4. Do not persist hidden chain-of-thought or entire chat transcripts. Chat/Work is for exploration and planning; Codex and other development agents implement against the repository; GitHub docs, issues, ADRs, and PRs are the durable shared state.
+5. Recheck links and run the lightweight documentation check before opening or updating a PR.

--- a/docs/project/handoff.md
+++ b/docs/project/handoff.md
@@ -8,7 +8,7 @@ Start with [AGENTS.md](../../AGENTS.md), then read the relevant [GitHub Issue](h
 
 ## Current milestone and status
 
-- **M7 — Append-only persistence and temporal/as-of state:** in progress. See the [canonical milestone map](../development/milestone-map.md), [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91), and [ADR-015](../adr/ADR-015.md).
+- **M7 — Append-only persistence and temporal/as-of state:** in progress. See the [canonical milestone map](../development/milestone-map.md) and [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91).
 - **M8 — Retrieval projections and review UI:** planned.
 - **M9 — Guarded actions, product signals, and integrated evaluation:** planned.
 - The initial M0–M6 evidence-first vertical slice is complete on `main`; the [root README](../../README.md) records the current product boundary and runnable entry points.
@@ -43,14 +43,14 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 
 ## Open decisions and questions
 
-- Which append-only persistence/database adapter should follow the M7 port, and what temporal correction evidence is required? Start with [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91) and ADR-015.
+- Which append-only persistence/database adapter should follow the M7 port, and what temporal correction evidence is required? Start with [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91) and the ADRs linked from that issue.
 - Which retrieval projections and fusion strategy earn adoption under the M8 evaluation plan? Start with [Issues #54, #55, #57, and #59](https://github.com/stauntonjr/procurement-intelligence-lab/issues/59).
 - Which review, guarded-action, and product-feedback slices should be sequenced next? Use the [milestone map](../development/milestone-map.md) and linked issue acceptance criteria.
 
 ## Recommended next work
 
 1. Review and merge the active M7/related governance PRs only after their checks and acceptance evidence are current.
-2. Continue M7 from Issue #91 and ADR-015; preserve append-only and temporal semantics.
+2. Continue M7 from Issue #91; preserve append-only and temporal semantics.
 3. Record any changed milestone/status mapping in the milestone map and update this index when the change materially affects onboarding.
 4. Before selecting retrieval or agent frameworks, run the repository's stated evaluation and benchmark work.
 

--- a/docs/project/handoff.md
+++ b/docs/project/handoff.md
@@ -21,7 +21,7 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 
 - M0–M4 repository, evidence, claims, and constrained chat foundations.
 - M5 local HTTP chat/evidence inspector; see [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82).
-- M6 durable identifiers, source viewer, and review context; see [PRs #86, #88, and #90](https://github.com/stauntonjr/procurement-intelligence-lab/pull/90).
+- M6 durable identifiers, source viewer, and review context; see [PR #86](https://github.com/stauntonjr/procurement-intelligence-lab/pull/86), [PR #88](https://github.com/stauntonjr/procurement-intelligence-lab/pull/88), and [PR #90](https://github.com/stauntonjr/procurement-intelligence-lab/pull/90).
 - Initial procurement query contracts and public-dataset planning; see [draft PR #76](https://github.com/stauntonjr/procurement-intelligence-lab/pull/76).
 
 ## Active work and PRs


### PR DESCRIPTION
## Summary

Formalize repository artifacts as the durable interoperability and memory layer across ChatGPT, Work, Codex, humans, and other development agents.

## What changed

- Add `docs/project/handoff.md` as a concise fresh-agent onboarding index.
- Add an explicit canonical-memory and conversation-boundary rule to `AGENTS.md`.
- Link the handoff from `README.md`.
- Extend the existing low-noise `make check` architecture presence gate to require the handoff page.
- Correct the handoff to link only to verified current repository artifacts and live Issues/PRs.

## Why

ChatGPT/Work conversations are useful for exploration and planning, while Codex and other development agents implement against the repository. GitHub Issues, ADRs, docs, and PRs provide the durable shared state needed to avoid siloed conversation history without persisting hidden chain-of-thought or entire transcripts.

## Scope

Documentation/governance only. No product architecture or implementation behavior changes.

## Validation

- Remote verification confirmed the new files and all handoff document links used in the branch.
- Local `make check` could not run because this task environment contains no repository checkout; the existing PR checks should provide the code/test validation.