### PR TITLE
feat: define rebuildable retrieval projection lifecycle

### DIFF
--- a/docs/adr/018-rebuildable-retrieval-projections.md
+++ b/docs/adr/018-rebuildable-retrieval-projections.md
@@ -1,0 +1,21 @@
+# ADR-018: Rebuildable retrieval projections behind a lifecycle port
+
+Status: accepted
+
+## Context
+
+Lexical, vector, and graph retrieval can accelerate investigation, but none may become an independent source of truth. The append-only assertion ledger remains canonical, and every retrieval result must retain source and epistemic context.
+
+The first retrieval slice needs explicit build, rebuild, version, freshness, failure, and deletion semantics without selecting a vector database, graph store, or production search service.
+
+## Decision
+
+Define a typed RetrievalProjection port. A build receives only canonical AssertionLedgerEntry records and a versioned build request. It produces an immutable manifest containing the projection identity, kind, implementation version, configuration digest, source entry IDs, source as-of time, lifecycle status, and record time.
+
+Only a ready projection may serve results. Failed or deleted projections must reject retrieval rather than silently serving stale content. Results retain their ledger entry, source assertion, evidence, projection-manifest identity, score, and epistemic status.
+
+The dependency-free reference adapter is an in-memory lexical projection. Vector and graph adapters remain future replaceable implementations of the same port.
+
+## Consequences
+
+Projection state is derived and rebuildable from assertion history. A future adapter may use a search, vector, or graph system, but must preserve manifest and lifecycle semantics. The port does not choose a durable canonical database, implement generic event sourcing, or establish retrieval quality; benchmark and adapter-selection work remains separate.

--- a/docs/development/milestone-map.md
+++ b/docs/development/milestone-map.md
@@ -12,7 +12,7 @@ This is the canonical map from the current implementation to the architecture. M
 | M5 | Local HTTP chat/evidence inspector | Complete | [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82) |
 | M6 | Durable identifiers, source viewer, and review context | Complete | [PRs #86, #88, and #90](https://github.com/stauntonjr/procurement-intelligence-lab/pull/90), ADRs 013–014 |
 | M7 | Append-only persistence, temporal state, anomaly taxonomy, and execution provenance | In progress | [PR #92](https://github.com/stauntonjr/procurement-intelligence-lab/pull/92), [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60), ADRs 015–017 |
-| M8 | Retrieval projections and review UI | Planned | Labeled retrieval evaluation and review workflows |
+| M8 | Retrieval projections and review UI | In progress | Issue #54, ADR-018, retrieval lifecycle contract |
 | M9 | Guarded actions, product signals, and integrated evaluation | Planned | Approval gates, sanitized feedback loop, release evidence |
 
 ## Status rules

--- a/docs/project/handoff.md
+++ b/docs/project/handoff.md
@@ -9,7 +9,7 @@ Start with [AGENTS.md](../../AGENTS.md), then read the relevant [GitHub Issue](h
 ## Current milestone and status
 
 - **M7 — Append-only persistence, temporal/as-of state, anomaly taxonomy, and execution provenance:** in progress. The ledger boundary and the first anomaly/provenance contract are on `main`; remaining work includes temporal correction, durable storage, and complete transformation provenance. See the [canonical milestone map](../development/milestone-map.md), [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60), and [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98).
-- **M8 — Retrieval projections and review UI:** planned. The foundation is [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54).
+- **M8 — Retrieval projections and review UI:** in progress. The rebuildable projection lifecycle foundation is [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54).
 - **M9 — Guarded actions, product signals, and integrated evaluation:** planned.
 - The initial M0–M6 evidence-first vertical slice is complete on `main`; the [root README](../../README.md) records the current product boundary and runnable entry points.
 
@@ -28,7 +28,7 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 
 ## Active work and PRs
 
-- No implementation pull requests are currently open.
+- The retrieval lifecycle slice for [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54) is active; it adds a derived, rebuildable lexical reference projection without selecting a search, vector, or graph store.
 - [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98) scopes end-to-end transformation provenance from artifacts through structuring, mapping, assertions, and decisions.
 - [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54) scopes rebuildable retrieval projection ports and lifecycle.
 - M6 follow-on review work remains tracked by [Issues #85, #87, and #89](https://github.com/stauntonjr/procurement-intelligence-lab/issues/89).
@@ -54,7 +54,7 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 
 1. Run the [roadmap stewardship protocol](../development/roadmap-stewardship.md) and resolve confirmed durable-record drift through normal Issues and PRs.
 2. Prioritize [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98) before model-backed structuring or graph/hypergraph persistence decisions.
-3. Continue with [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54) when its retrieval port can be built from canonical assertion history and the current provenance contract.
+3. Complete and review [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54); use its lifecycle contract as the boundary for later lexical, vector, and graph adapters.
 4. Before selecting retrieval or agent frameworks, run the repository's stated evaluation and benchmark work.
 
 ## Refresh protocol

--- a/src/procurement_intelligence_lab/adapters/memory_retrieval.py
+++ b/src/procurement_intelligence_lab/adapters/memory_retrieval.py
@@ -1,0 +1,122 @@
+"""Dependency-free lexical retrieval projection reference adapter."""
+
+from datetime import datetime
+
+from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+from procurement_intelligence_lab.domain.retrieval import (
+    ProjectionBuildRequest,
+    ProjectionManifest,
+    ProjectionStatus,
+    RetrievalHit,
+    source_entry_ids,
+)
+
+
+class InMemoryLexicalProjection:
+    """A rebuildable, derived index; the assertion ledger remains canonical."""
+
+    def __init__(self) -> None:
+        self._manifests: dict[str, ProjectionManifest] = {}
+        self._entries: dict[str, tuple[AssertionLedgerEntry, ...]] = {}
+
+    def build(
+        self,
+        entries: tuple[AssertionLedgerEntry, ...],
+        *,
+        request: ProjectionBuildRequest,
+    ) -> ProjectionManifest:
+        source_as_of = max(
+            (entry.observed_at for entry in entries),
+            default=request.requested_at,
+        )
+        manifest = ProjectionManifest(
+            projection_id=request.projection_id,
+            kind=request.kind,
+            implementation_version=request.implementation_version,
+            config_digest=request.config_digest,
+            source_entry_ids=source_entry_ids(entries),
+            source_as_of=source_as_of,
+            status=ProjectionStatus.READY,
+            recorded_at=request.requested_at,
+        )
+        self._entries[request.projection_id] = entries
+        self._manifests[request.projection_id] = manifest
+        return manifest
+
+    def status(self, projection_id: str) -> ProjectionManifest | None:
+        return self._manifests.get(projection_id)
+
+    def search(
+        self, projection_id: str, query: str, *, limit: int = 10
+    ) -> tuple[RetrievalHit, ...]:
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        manifest = self._manifests.get(projection_id)
+        if manifest is None or manifest.status is not ProjectionStatus.READY:
+            raise LookupError("projection is not ready")
+        terms = tuple(term for term in query.casefold().split() if term)
+        if not terms:
+            return ()
+        hits: list[RetrievalHit] = []
+        for entry in self._entries[projection_id]:
+            assertion = entry.assertion
+            text = " ".join(
+                (assertion.subject_key, assertion.predicate.value, str(assertion.value))
+            ).casefold()
+            matched = sum(term in text for term in terms)
+            if matched:
+                hits.append(RetrievalHit(entry, matched / len(terms), manifest.manifest_id))
+        return tuple(
+            sorted(hits, key=lambda hit: (-hit.score, hit.entry.entry_id))[:limit]
+        )
+
+    def fail(
+        self, projection_id: str, *, reason: str, recorded_at: datetime
+    ) -> ProjectionManifest:
+        if recorded_at.tzinfo is None:
+            raise ValueError("recorded_at must be timezone-aware")
+        previous = self._require_manifest(projection_id)
+        self._entries.pop(projection_id, None)
+        return self._record(
+            previous,
+            status=ProjectionStatus.FAILED,
+            recorded_at=recorded_at,
+            failure_reason=reason,
+        )
+
+    def delete(self, projection_id: str, *, recorded_at: datetime) -> ProjectionManifest:
+        if recorded_at.tzinfo is None:
+            raise ValueError("recorded_at must be timezone-aware")
+        previous = self._require_manifest(projection_id)
+        self._entries.pop(projection_id, None)
+        return self._record(
+            previous, status=ProjectionStatus.DELETED, recorded_at=recorded_at
+        )
+
+    def _require_manifest(self, projection_id: str) -> ProjectionManifest:
+        manifest = self._manifests.get(projection_id)
+        if manifest is None:
+            raise LookupError("projection does not exist")
+        return manifest
+
+    def _record(
+        self,
+        previous: ProjectionManifest,
+        *,
+        status: ProjectionStatus,
+        recorded_at: datetime,
+        failure_reason: str | None = None,
+    ) -> ProjectionManifest:
+        manifest = ProjectionManifest(
+            projection_id=previous.projection_id,
+            kind=previous.kind,
+            implementation_version=previous.implementation_version,
+            config_digest=previous.config_digest,
+            source_entry_ids=previous.source_entry_ids,
+            source_as_of=previous.source_as_of,
+            status=status,
+            recorded_at=recorded_at,
+            failure_reason=failure_reason,
+        )
+        self._manifests[previous.projection_id] = manifest
+        return manifest

--- a/src/procurement_intelligence_lab/adapters/memory_retrieval.py
+++ b/src/procurement_intelligence_lab/adapters/memory_retrieval.py
@@ -66,13 +66,9 @@ class InMemoryLexicalProjection:
             matched = sum(term in text for term in terms)
             if matched:
                 hits.append(RetrievalHit(entry, matched / len(terms), manifest.manifest_id))
-        return tuple(
-            sorted(hits, key=lambda hit: (-hit.score, hit.entry.entry_id))[:limit]
-        )
+        return tuple(sorted(hits, key=lambda hit: (-hit.score, hit.entry.entry_id))[:limit])
 
-    def fail(
-        self, projection_id: str, *, reason: str, recorded_at: datetime
-    ) -> ProjectionManifest:
+    def fail(self, projection_id: str, *, reason: str, recorded_at: datetime) -> ProjectionManifest:
         if recorded_at.tzinfo is None:
             raise ValueError("recorded_at must be timezone-aware")
         previous = self._require_manifest(projection_id)
@@ -89,9 +85,7 @@ class InMemoryLexicalProjection:
             raise ValueError("recorded_at must be timezone-aware")
         previous = self._require_manifest(projection_id)
         self._entries.pop(projection_id, None)
-        return self._record(
-            previous, status=ProjectionStatus.DELETED, recorded_at=recorded_at
-        )
+        return self._record(previous, status=ProjectionStatus.DELETED, recorded_at=recorded_at)
 
     def _require_manifest(self, projection_id: str) -> ProjectionManifest:
         manifest = self._manifests.get(projection_id)

--- a/src/procurement_intelligence_lab/domain/retrieval.py
+++ b/src/procurement_intelligence_lab/domain/retrieval.py
@@ -1,0 +1,91 @@
+"""Rebuildable retrieval projection contracts."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from procurement_intelligence_lab.domain.identity import stable_id
+from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+
+
+class ProjectionKind(StrEnum):
+    LEXICAL = "lexical"
+    VECTOR = "vector"
+    GRAPH = "graph"
+
+
+class ProjectionStatus(StrEnum):
+    READY = "ready"
+    FAILED = "failed"
+    DELETED = "deleted"
+
+
+@dataclass(frozen=True)
+class ProjectionBuildRequest:
+    projection_id: str
+    kind: ProjectionKind
+    implementation_version: str
+    config_digest: str
+    requested_at: datetime
+
+    def __post_init__(self) -> None:
+        if not self.projection_id:
+            raise ValueError("projection_id is required")
+        if not self.implementation_version:
+            raise ValueError("implementation_version is required")
+        if not self.config_digest:
+            raise ValueError("config_digest is required")
+        if self.requested_at.tzinfo is None:
+            raise ValueError("requested_at must be timezone-aware")
+
+
+@dataclass(frozen=True)
+class ProjectionManifest:
+    projection_id: str
+    kind: ProjectionKind
+    implementation_version: str
+    config_digest: str
+    source_entry_ids: tuple[str, ...]
+    source_as_of: datetime
+    status: ProjectionStatus
+    recorded_at: datetime
+    failure_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.source_as_of.tzinfo is None or self.recorded_at.tzinfo is None:
+            raise ValueError("projection timestamps must be timezone-aware")
+        if self.status is ProjectionStatus.FAILED and not self.failure_reason:
+            raise ValueError("failed projections require a failure_reason")
+        if self.status is not ProjectionStatus.FAILED and self.failure_reason is not None:
+            raise ValueError("only failed projections may carry a failure_reason")
+
+    @property
+    def manifest_id(self) -> str:
+        return stable_id(
+            "projection-manifest",
+            self.projection_id,
+            self.kind.value,
+            self.implementation_version,
+            self.config_digest,
+            self.source_entry_ids,
+            self.source_as_of.isoformat(),
+            self.status.value,
+            self.recorded_at.isoformat(),
+            self.failure_reason,
+        )
+
+
+@dataclass(frozen=True)
+class RetrievalHit:
+    entry: AssertionLedgerEntry
+    score: float
+    projection_manifest_id: str
+    epistemic_status: str = "source_assertion"
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.score <= 1.0:
+            raise ValueError("score must be in (0, 1]")
+
+
+def source_entry_ids(entries: tuple[AssertionLedgerEntry, ...]) -> tuple[str, ...]:
+    return tuple(entry.entry_id for entry in entries)

--- a/src/procurement_intelligence_lab/ports/retrieval.py
+++ b/src/procurement_intelligence_lab/ports/retrieval.py
@@ -1,0 +1,34 @@
+"""Outbound ports for rebuildable retrieval projections."""
+
+from datetime import datetime
+from typing import Protocol
+
+from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+from procurement_intelligence_lab.domain.retrieval import (
+    ProjectionBuildRequest,
+    ProjectionManifest,
+    RetrievalHit,
+)
+
+
+class RetrievalProjection(Protocol):
+    """A derived index built only from canonical assertion-ledger entries."""
+
+    def build(
+        self,
+        entries: tuple[AssertionLedgerEntry, ...],
+        *,
+        request: ProjectionBuildRequest,
+    ) -> ProjectionManifest: ...
+
+    def status(self, projection_id: str) -> ProjectionManifest | None: ...
+
+    def search(
+        self, projection_id: str, query: str, *, limit: int = 10
+    ) -> tuple[RetrievalHit, ...]: ...
+
+    def fail(
+        self, projection_id: str, *, reason: str, recorded_at: datetime
+    ) -> ProjectionManifest: ...
+
+    def delete(self, projection_id: str, *, recorded_at: datetime) -> ProjectionManifest: ...

--- a/tests/unit/test_retrieval_projection.py
+++ b/tests/unit/test_retrieval_projection.py
@@ -19,9 +19,7 @@ def _entries() -> tuple[AssertionLedgerEntry, ...]:
     ledger = InMemoryAssertionLedger()
     evidence = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B"))
     first = ledger.append(
-        SourceAssertion(
-            "GPU-A", AssertionPredicate.HAS_QUANTITY, Decimal("4"), evidence
-        ),
+        SourceAssertion("GPU-A", AssertionPredicate.HAS_QUANTITY, Decimal("4"), evidence),
         observed_at=datetime(2026, 1, 1, tzinfo=UTC),
     )
     second = ledger.append(
@@ -72,9 +70,7 @@ def test_failed_or_deleted_projection_cannot_silently_serve_stale_results() -> N
         projection.search("lexical-bom", "GPU")
 
     rebuilt = projection.build(_entries(), request=_request())
-    deleted = projection.delete(
-        "lexical-bom", recorded_at=datetime(2026, 1, 5, tzinfo=UTC)
-    )
+    deleted = projection.delete("lexical-bom", recorded_at=datetime(2026, 1, 5, tzinfo=UTC))
     assert rebuilt.status is ProjectionStatus.READY
     assert deleted.status is ProjectionStatus.DELETED
     with pytest.raises(LookupError, match="not ready"):

--- a/tests/unit/test_retrieval_projection.py
+++ b/tests/unit/test_retrieval_projection.py
@@ -7,6 +7,7 @@ from procurement_intelligence_lab.adapters.memory_ledger import InMemoryAssertio
 from procurement_intelligence_lab.adapters.memory_retrieval import InMemoryLexicalProjection
 from procurement_intelligence_lab.domain.assertions import AssertionPredicate, SourceAssertion
 from procurement_intelligence_lab.domain.bom import EvidenceRef
+from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
 from procurement_intelligence_lab.domain.retrieval import (
     ProjectionBuildRequest,
     ProjectionKind,
@@ -14,15 +15,22 @@ from procurement_intelligence_lab.domain.retrieval import (
 )
 
 
-def _entries() -> tuple:
+def _entries() -> tuple[AssertionLedgerEntry, ...]:
     ledger = InMemoryAssertionLedger()
     evidence = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B"))
     first = ledger.append(
-        SourceAssertion("GPU-A", AssertionPredicate.HAS_QUANTITY, Decimal("4"), evidence),
+        SourceAssertion(
+            "GPU-A", AssertionPredicate.HAS_QUANTITY, Decimal("4"), evidence
+        ),
         observed_at=datetime(2026, 1, 1, tzinfo=UTC),
     )
     second = ledger.append(
-        SourceAssertion("GPU-B", AssertionPredicate.HAS_DESCRIPTION, "GPU accelerator", evidence),
+        SourceAssertion(
+            "GPU-B",
+            AssertionPredicate.HAS_DESCRIPTION,
+            "GPU accelerator",
+            evidence,
+        ),
         observed_at=datetime(2026, 1, 2, tzinfo=UTC),
     )
     return first, second
@@ -55,14 +63,18 @@ def test_failed_or_deleted_projection_cannot_silently_serve_stale_results() -> N
     projection.build(_entries(), request=_request())
 
     failed = projection.fail(
-        "lexical-bom", reason="index corruption", recorded_at=datetime(2026, 1, 4, tzinfo=UTC)
+        "lexical-bom",
+        reason="index corruption",
+        recorded_at=datetime(2026, 1, 4, tzinfo=UTC),
     )
     assert failed.status is ProjectionStatus.FAILED
     with pytest.raises(LookupError, match="not ready"):
         projection.search("lexical-bom", "GPU")
 
     rebuilt = projection.build(_entries(), request=_request())
-    deleted = projection.delete("lexical-bom", recorded_at=datetime(2026, 1, 5, tzinfo=UTC))
+    deleted = projection.delete(
+        "lexical-bom", recorded_at=datetime(2026, 1, 5, tzinfo=UTC)
+    )
     assert rebuilt.status is ProjectionStatus.READY
     assert deleted.status is ProjectionStatus.DELETED
     with pytest.raises(LookupError, match="not ready"):
@@ -72,5 +84,9 @@ def test_failed_or_deleted_projection_cannot_silently_serve_stale_results() -> N
 def test_projection_requires_explicit_lifecycle_inputs() -> None:
     with pytest.raises(ValueError, match="timezone-aware"):
         ProjectionBuildRequest(  # noqa: DTZ001
-            "lexical-bom", ProjectionKind.LEXICAL, "1", "config-v1", datetime(2026, 1, 3)
+            "lexical-bom",
+            ProjectionKind.LEXICAL,
+            "1",
+            "config-v1",
+            datetime(2026, 1, 3),
         )

--- a/tests/unit/test_retrieval_projection.py
+++ b/tests/unit/test_retrieval_projection.py
@@ -19,7 +19,7 @@ def _entries() -> tuple[AssertionLedgerEntry, ...]:
     ledger = InMemoryAssertionLedger()
     evidence = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B"))
     first = ledger.append(
-        SourceAssertion("GPU-A", AssertionPredicate.HAS_QUANTITY, Decimal("4"), evidence),
+        SourceAssertion("GPU-A", AssertionPredicate.HAS_QUANTITY, Decimal(4), evidence),
         observed_at=datetime(2026, 1, 1, tzinfo=UTC),
     )
     second = ledger.append(
@@ -79,10 +79,10 @@ def test_failed_or_deleted_projection_cannot_silently_serve_stale_results() -> N
 
 def test_projection_requires_explicit_lifecycle_inputs() -> None:
     with pytest.raises(ValueError, match="timezone-aware"):
-        ProjectionBuildRequest(  # noqa: DTZ001
+        ProjectionBuildRequest(
             "lexical-bom",
             ProjectionKind.LEXICAL,
             "1",
             "config-v1",
-            datetime(2026, 1, 3),
+            datetime(2026, 1, 3),  # noqa: DTZ001
         )

--- a/tests/unit/test_retrieval_projection.py
+++ b/tests/unit/test_retrieval_projection.py
@@ -1,0 +1,76 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from procurement_intelligence_lab.adapters.memory_ledger import InMemoryAssertionLedger
+from procurement_intelligence_lab.adapters.memory_retrieval import InMemoryLexicalProjection
+from procurement_intelligence_lab.domain.assertions import AssertionPredicate, SourceAssertion
+from procurement_intelligence_lab.domain.bom import EvidenceRef
+from procurement_intelligence_lab.domain.retrieval import (
+    ProjectionBuildRequest,
+    ProjectionKind,
+    ProjectionStatus,
+)
+
+
+def _entries() -> tuple:
+    ledger = InMemoryAssertionLedger()
+    evidence = EvidenceRef("bom.xlsx", "hash", "BOM", 2, ("A", "B"))
+    first = ledger.append(
+        SourceAssertion("GPU-A", AssertionPredicate.HAS_QUANTITY, Decimal("4"), evidence),
+        observed_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    second = ledger.append(
+        SourceAssertion("GPU-B", AssertionPredicate.HAS_DESCRIPTION, "GPU accelerator", evidence),
+        observed_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    return first, second
+
+
+def _request() -> ProjectionBuildRequest:
+    return ProjectionBuildRequest(
+        "lexical-bom",
+        ProjectionKind.LEXICAL,
+        "1",
+        "config-v1",
+        datetime(2026, 1, 3, tzinfo=UTC),
+    )
+
+
+def test_projection_builds_from_ledger_entries_and_exposes_source_metadata() -> None:
+    projection = InMemoryLexicalProjection()
+    manifest = projection.build(_entries(), request=_request())
+
+    assert manifest.status is ProjectionStatus.READY
+    assert len(manifest.source_entry_ids) == 2
+    hit = projection.search("lexical-bom", "accelerator")[0]
+    assert hit.entry.assertion.evidence.source_uri == "bom.xlsx"
+    assert hit.epistemic_status == "source_assertion"
+    assert hit.projection_manifest_id == manifest.manifest_id
+
+
+def test_failed_or_deleted_projection_cannot_silently_serve_stale_results() -> None:
+    projection = InMemoryLexicalProjection()
+    projection.build(_entries(), request=_request())
+
+    failed = projection.fail(
+        "lexical-bom", reason="index corruption", recorded_at=datetime(2026, 1, 4, tzinfo=UTC)
+    )
+    assert failed.status is ProjectionStatus.FAILED
+    with pytest.raises(LookupError, match="not ready"):
+        projection.search("lexical-bom", "GPU")
+
+    rebuilt = projection.build(_entries(), request=_request())
+    deleted = projection.delete("lexical-bom", recorded_at=datetime(2026, 1, 5, tzinfo=UTC))
+    assert rebuilt.status is ProjectionStatus.READY
+    assert deleted.status is ProjectionStatus.DELETED
+    with pytest.raises(LookupError, match="not ready"):
+        projection.search("lexical-bom", "GPU")
+
+
+def test_projection_requires_explicit_lifecycle_inputs() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        ProjectionBuildRequest(  # noqa: DTZ001
+            "lexical-bom", ProjectionKind.LEXICAL, "1", "config-v1", datetime(2026, 1, 3)
+        )

--- a/tests/unit/test_retrieval_projection.py
+++ b/tests/unit/test_retrieval_projection.py
@@ -51,7 +51,7 @@ def test_projection_builds_from_ledger_entries_and_exposes_source_metadata() -> 
     assert manifest.status is ProjectionStatus.READY
     assert len(manifest.source_entry_ids) == 2
     hit = projection.search("lexical-bom", "accelerator")[0]
-    assert hit.entry.assertion.evidence.source_uri == "bom.xlsx"
+    assert hit.entry.assertion.evidence.artifact_id == "bom.xlsx"
     assert hit.epistemic_status == "source_assertion"
     assert hit.projection_manifest_id == manifest.manifest_id
 


### PR DESCRIPTION
## Summary

Implement Issue #54's first retrieval slice: typed rebuildable-projection lifecycle contracts and a dependency-free in-memory lexical reference adapter.

## What changed

- Add domain contracts for projection kind, build request, immutable manifest, lifecycle status, and evidence-bearing retrieval hits.
- Add a RetrievalProjection port for build, status, search, failure, and deletion behavior.
- Add an in-memory lexical adapter built only from canonical AssertionLedgerEntry records.
- Reject search when a projection is failed or deleted; do not silently serve stale results.
- Add ADR-018 and lifecycle tests.
- Update the milestone map and handoff index.

## Why

Lexical, vector, and graph systems are useful derived projections, not canonical truth. This establishes the lifecycle boundary before selecting an external search/vector/graph implementation.

## Milestone and issue

- Primary milestone: M8 — Retrieval projections and review UI
- Linked issue: #54
- Acceptance evidence: manifests retain source entry IDs, source as-of time, implementation/config identities, lifecycle status, and retrieval results retain ledger/evidence context.

## Validation

CI will run Ruff, Pyright, and pytest. The adapter is intentionally dependency-free; retrieval quality benchmarking and external adapters remain follow-on work.

## Architectural impact

- [ ] No architecture boundary, invariant, or public contract changed
- [x] ADR added or updated
- [x] Existing ADR/docs reviewed for drift

## Synchronization

- [x] Milestone map updated
- [x] Project handoff updated
- [x] Material Chat/Work decisions captured in a durable doc
- [x] No confidential data