### PR TITLE
feat: record document transformation provenance

### DIFF
--- a/docs/adr/017-execution-and-decision-provenance.md
+++ b/docs/adr/017-execution-and-decision-provenance.md
@@ -1,4 +1,4 @@
-# ADR-017: Execution and decision provenance
+# ADR-017: Execution, decision, and transformation provenance
 
 Status: accepted
 
@@ -8,19 +8,26 @@ The repository needs to explain not only what evidence supported a result, but w
 
 Decision records therefore need an immutable, resolved reference to the execution that produced them. Deterministic components need implementation and policy identity even when no model is involved. Model-backed components additionally need provider, model ID, resolved model revision, prompt, and schema identity.
 
+Source/evidence provenance and execution provenance answer different questions. Evidence identifies what a source artifact said and where it said it. Execution provenance identifies which transformation or decision produced a derived runtime object. Neither replaces the other.
+
 ## Decision
 
-Introduce two related contracts:
+Introduce three related contracts:
 
-- ProvenanceContext is the normalized effective execution manifest. It contains the run ID, workflow identity, code revision, container image digest, effective configuration digest, dependency-lock digest, input snapshot IDs, start time, environment, and optional parent run.
-- DecisionProvenance identifies the component that made a decision and links it to ProvenanceContext. It records whether the component was deterministic, model-based, or human; its implementation version; policy version; and, for model components, provider, model ID, resolved model revision, prompt version, and schema version.
+- `ProvenanceContext` is the normalized effective execution manifest. It contains the run ID, workflow identity, code revision, container image digest, effective configuration digest, dependency-lock digest, input snapshot IDs, start time, environment, and optional parent run.
+- `DecisionProvenance` identifies the component that made a transformation or decision and links it to `ProvenanceContext`. It records whether the component was deterministic, model-based, or human; its implementation version; policy version; and, for model components, provider, model ID, resolved model revision, prompt version, and schema version.
+- `TransformationEvent` is an immutable event for structuring or mapping. It records typed relationships to durable inputs and schemas, output IDs, optional parent events, and the responsible `DecisionProvenance`. The event graph supports multiple inputs and branching; a single-parent path remains straightforward.
 
-The composition root or orchestrator creates ProvenanceContext from the resolved Docker Compose/configuration inputs and injects it into application services. Domain decision functions receive DecisionProvenance explicitly. Records retain the resolved provenance rather than relying on a mutable configuration path.
+The composition root or orchestrator creates `ProvenanceContext` from the resolved Docker Compose/configuration inputs and injects it into application services. Domain decision functions receive `DecisionProvenance` explicitly. Records retain the resolved provenance rather than relying on a mutable configuration path.
+
+The initial vertical slice records the deterministic XLSX BOM structurer's source-artifact hash, implementation version, schema version, execution context, structured output, and event ID. Assertions emitted from that result retain the event ID in addition to their `EvidenceRef`.
 
 The local development fallback is explicitly marked with working-tree/local identities and is not production reproducibility evidence.
 
 ## Consequences
 
-An anomaly, entity-resolution decision, reconciliation result, and later derived claim can be audited against both evidence and the execution/component that produced it. Re-running with a changed configuration, model revision, policy, or code revision yields distinct provenance identities.
+An anomaly, entity-resolution decision, reconciliation result, and later derived claim can be audited against both evidence and the execution/component that produced it. Re-running with a changed configuration, model revision, policy, code revision, parser implementation, prompt, or schema yields distinct provenance identities.
 
-Secrets and raw environment values must not be included in the manifest; only an allowlisted, sanitized environment fingerprint may be retained. External model providers must resolve mutable aliases to an immutable revision where the provider supports it.
+Secrets and raw environment values must not be included in the manifest; only an allowlisted, sanitized environment fingerprint may be retained. External model providers must resolve mutable aliases to an immutable revision where the provider supports it. Raw prompts, hidden reasoning, and complete chat transcripts are not provenance payloads.
+
+Relational foreign keys may persist event/context references, but the conceptual model is an immutable directed acyclic graph rather than a linked list or a required graph database.

--- a/docs/domain/semantic-model.md
+++ b/docs/domain/semantic-model.md
@@ -1,7 +1,8 @@
 # Semantic model
 
 ```text
-Artifact → StructuredDocument → MappedDocument → Normalized observations
+Artifact → [Structuring transformation event] → StructuredDocument
+→ [Mapping transformation event] → MappedDocument → Normalized observations
 → Source Assertions → Entity Mentions → Entity Resolution Decisions
 → Canonicalized Assertions → Reconciliation → Operational State
 → Derived Facts → Anomalies → Predictions → Decisions → Actions
@@ -9,5 +10,8 @@ Artifact → StructuredDocument → MappedDocument → Normalized observations
 
 An Artifact is the immutable source boundary. Structure describes what was found; mapping assigns fields to a schema. Normalized observations make values comparable. Source assertions record claims plus source location, extraction method, confidence, timestamps, and epistemic status. They are not truth.
 
+Each structuring or mapping transformation records an immutable provenance event with typed relationships to durable inputs, schemas, optional parent events, outputs, and the execution/component context. Deterministic transformations record implementation identity and version. Model-backed transformations also record provider, model ID, immutable model revision, prompt/template version, and schema version. Source assertions retain both their `EvidenceRef` and the originating transformation-event reference.
+
 Entity Mentions and resolution decisions operate downstream of source assertions and upstream of canonical state. Reconciliation selects governing claims under explicit policy, retaining losing/conflicting claims and provenance. Every later layer carries EvidenceRefs back through the chain. Predictions, decisions, and actions are derived outputs with separate authority and review controls.
 
+Execution provenance is an immutable directed acyclic event graph: a simple document path may have one parent, while reprocessing, human review, overrides, and shared inputs may introduce typed multi-parent relationships. It does not store raw prompts, secrets, hidden reasoning, or complete chat transcripts.

--- a/docs/project/handoff.md
+++ b/docs/project/handoff.md
@@ -9,7 +9,7 @@ Start with [AGENTS.md](../../AGENTS.md), then read the relevant [GitHub Issue](h
 ## Current milestone and status
 
 - **M7 — Append-only persistence, temporal/as-of state, anomaly taxonomy, and execution provenance:** in progress. The ledger boundary and the first anomaly/provenance contract are on `main`; remaining work includes temporal correction, durable storage, and complete transformation provenance. See the [canonical milestone map](../development/milestone-map.md), [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60), and [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98).
-- **M8 — Retrieval projections and review UI:** in progress. The rebuildable projection lifecycle foundation is [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54).
+- **M8 — Retrieval projections and review UI:** in progress. The rebuildable projection lifecycle foundation is complete; later adapter work remains. See [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54).
 - **M9 — Guarded actions, product signals, and integrated evaluation:** planned.
 - The initial M0–M6 evidence-first vertical slice is complete on `main`; the [root README](../../README.md) records the current product boundary and runnable entry points.
 
@@ -25,12 +25,12 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 - M7 ledger boundary and initial anomaly/execution-provenance contract; see [PR #92](https://github.com/stauntonjr/procurement-intelligence-lab/pull/92) and [PR #94](https://github.com/stauntonjr/procurement-intelligence-lab/pull/94).
 - Layered deterministic and advisory PR review governance; see [PR #93](https://github.com/stauntonjr/procurement-intelligence-lab/pull/93).
 - Canonical shared project-memory convention; see [PR #96](https://github.com/stauntonjr/procurement-intelligence-lab/pull/96).
+- M8 rebuildable lexical retrieval-projection lifecycle foundation; see [PR #101](https://github.com/stauntonjr/procurement-intelligence-lab/pull/101) and [ADR-018](../adr/018-rebuildable-retrieval-projections.md).
 
 ## Active work and PRs
 
-- The retrieval lifecycle slice for [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54) is active; it adds a derived, rebuildable lexical reference projection without selecting a search, vector, or graph store.
-- [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98) scopes end-to-end transformation provenance from artifacts through structuring, mapping, assertions, and decisions.
-- [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54) scopes rebuildable retrieval projection ports and lifecycle.
+- [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98) is the active M7.2 slice: it establishes an immutable transformation-event contract and first traces the deterministic XLSX structurer into source assertions.
+- [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54) is complete. Follow-on M8 work includes [Issues #55, #57, #59, #62, and #63](https://github.com/stauntonjr/procurement-intelligence-lab/issues/63); preserve their dependencies and evaluation gates.
 - M6 follow-on review work remains tracked by [Issues #85, #87, and #89](https://github.com/stauntonjr/procurement-intelligence-lab/issues/89).
 
 ## Settled decisions
@@ -46,15 +46,15 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 ## Open decisions and questions
 
 - Which append-only persistence/database adapter should follow the M7 port, and what temporal correction evidence is required? Start with [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91) and the ADRs linked from that issue.
-- How should transformation provenance be represented from artifacts through structure, mapping, assertions, and decisions? Start with [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98).
-- Which retrieval projections and fusion strategy earn adoption under the M8 evaluation plan? Start with [Issues #54, #55, #57, and #59](https://github.com/stauntonjr/procurement-intelligence-lab/issues/59).
+- How should transformation provenance extend from the deterministic XLSX slice to mapping, model-backed structuring, and downstream decisions? Start with [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98).
+- Which retrieval projections and fusion strategy earn adoption under the M8 evaluation plan? Start with [Issues #55, #57, and #59](https://github.com/stauntonjr/procurement-intelligence-lab/issues/59).
 - Which review, guarded-action, and product-feedback slices should be sequenced next? Use the [milestone map](../development/milestone-map.md) and linked issue acceptance criteria.
 
 ## Recommended next work
 
-1. Run the [roadmap stewardship protocol](../development/roadmap-stewardship.md) and resolve confirmed durable-record drift through normal Issues and PRs.
-2. Prioritize [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98) before model-backed structuring or graph/hypergraph persistence decisions.
-3. Complete and review [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54); use its lifecycle contract as the boundary for later lexical, vector, and graph adapters.
+1. Complete and review [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98); retain the deterministic XLSX vertical as the reference before extending it to model-backed structuring or graph/hypergraph persistence.
+2. Run the [roadmap stewardship protocol](../development/roadmap-stewardship.md) and resolve confirmed durable-record drift through normal Issues and PRs.
+3. Sequence later retrieval adapters only after their prerequisites, scope filters, and evaluation evidence are ready.
 4. Before selecting retrieval or agent frameworks, run the repository's stated evaluation and benchmark work.
 
 ## Refresh protocol

--- a/src/procurement_intelligence_lab/adapters/xlsx.py
+++ b/src/procurement_intelligence_lab/adapters/xlsx.py
@@ -126,7 +126,9 @@ def read_bom_with_provenance(
     context = provenance_context or local_provenance_context()
     context = replace(
         context,
-        input_snapshot_ids=tuple(\n            dict.fromkeys((*context.input_snapshot_ids, artifact_snapshot_id))\n        ),
+        input_snapshot_ids=tuple(
+            dict.fromkeys((*context.input_snapshot_ids, artifact_snapshot_id))
+        ),
     )
     provenance = DecisionProvenance(
         context,

--- a/src/procurement_intelligence_lab/adapters/xlsx.py
+++ b/src/procurement_intelligence_lab/adapters/xlsx.py
@@ -1,18 +1,48 @@
 """Minimal dependency-free XLSX BOM adapter for synthetic fixtures."""
 
+from dataclasses import dataclass, replace
 from decimal import Decimal
 from hashlib import sha256
 from pathlib import Path
 from xml.etree import ElementTree as ET
 from zipfile import ZipFile
 
+from procurement_intelligence_lab.domain.assertions import (
+    SourceAssertion,
+    assertions_for_bom,
+)
 from procurement_intelligence_lab.domain.bom import Bom, BomLine, EvidenceRef
+from procurement_intelligence_lab.domain.provenance import (
+    ComponentKind,
+    DecisionProvenance,
+    ProvenanceContext,
+    ProvenanceEdge,
+    ProvenanceRelation,
+    TransformationEvent,
+    local_provenance_context,
+)
 
 
 _NS = {
     "x": "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
     "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
 }
+_STRUCTURER_NAME = "xlsx-bom-structurer"
+_STRUCTURER_VERSION = "1"
+_BOM_SCHEMA_VERSION = "bom-xlsx-v1"
+
+
+@dataclass(frozen=True)
+class XlsxStructuredBom:
+    """A parsed BOM and the event that structured its source artifact."""
+
+    bom: Bom
+    transformation: TransformationEvent
+
+    def source_assertions(self) -> tuple[SourceAssertion, ...]:
+        """Return assertions that retain both source and execution provenance."""
+
+        return assertions_for_bom(self.bom, self.transformation.event_id)
 
 
 def _text(node: ET.Element | None) -> str:
@@ -27,6 +57,20 @@ def _cell_value(cell: ET.Element, shared_strings: list[str]) -> str:
 
 
 def read_bom(path: str | Path, sheet: str = "BOM") -> Bom:
+    """Read a BOM while preserving the original simple adapter boundary."""
+
+    return read_bom_with_provenance(path, sheet).bom
+
+
+def read_bom_with_provenance(
+    path: str | Path,
+    sheet: str = "BOM",
+    provenance_context: ProvenanceContext | None = None,
+    implementation_version: str = _STRUCTURER_VERSION,
+    schema_version: str = _BOM_SCHEMA_VERSION,
+) -> XlsxStructuredBom:
+    """Read a BOM and record the deterministic structuring transformation."""
+
     raw = Path(path).read_bytes()
     with ZipFile(path) as archive:
         shared = (
@@ -60,6 +104,7 @@ def read_bom(path: str | Path, sheet: str = "BOM") -> Bom:
     if not rows or rows[0][:4] != ["SKU", "Description", "Quantity", "Unit Price"]:
         raise ValueError("expected BOM headers: SKU, Description, Quantity, Unit Price")
 
+    artifact_id = str(path)
     digest = sha256(raw).hexdigest()
     lines: list[BomLine] = []
     for row_number, row in enumerate(rows[1:], start=2):
@@ -73,7 +118,31 @@ def read_bom(path: str | Path, sheet: str = "BOM") -> Bom:
                 padded[1],
                 Decimal(padded[2]),
                 price,
-                EvidenceRef(path.__str__(), digest, sheet, row_number, ("A", "B", "C", "D")),
+                EvidenceRef(artifact_id, digest, sheet, row_number, ("A", "B", "C", "D")),
             )
         )
-    return Bom(path.__str__(), tuple(lines))
+
+    artifact_snapshot_id = f"artifact:{digest}"
+    context = provenance_context or local_provenance_context()
+    context = replace(
+        context,
+        input_snapshot_ids=tuple(dict.fromkeys((*context.input_snapshot_ids, artifact_snapshot_id))),
+    )
+    provenance = DecisionProvenance(
+        context,
+        _STRUCTURER_NAME,
+        ComponentKind.DETERMINISTIC,
+        implementation_version,
+        schema_version=schema_version,
+    )
+    bom = Bom(artifact_id, tuple(lines))
+    transformation = TransformationEvent(
+        "document-structuring",
+        provenance,
+        (
+            ProvenanceEdge(ProvenanceRelation.USED_INPUT, artifact_snapshot_id),
+            ProvenanceEdge(ProvenanceRelation.USED_SCHEMA, f"schema:{schema_version}"),
+        ),
+        (f"structured-bom:{digest}:{sheet}",),
+    )
+    return XlsxStructuredBom(bom, transformation)

--- a/src/procurement_intelligence_lab/adapters/xlsx.py
+++ b/src/procurement_intelligence_lab/adapters/xlsx.py
@@ -126,7 +126,7 @@ def read_bom_with_provenance(
     context = provenance_context or local_provenance_context()
     context = replace(
         context,
-        input_snapshot_ids=tuple(dict.fromkeys((*context.input_snapshot_ids, artifact_snapshot_id))),
+        input_snapshot_ids=tuple(\n            dict.fromkeys((*context.input_snapshot_ids, artifact_snapshot_id))\n        ),
     )
     provenance = DecisionProvenance(
         context,

--- a/src/procurement_intelligence_lab/domain/assertions.py
+++ b/src/procurement_intelligence_lab/domain/assertions.py
@@ -22,6 +22,7 @@ class SourceAssertion:
     value: str | Decimal
     evidence: EvidenceRef
     source_system: str = "document"
+    transformation_event_id: str | None = None
 
     @property
     def assertion_id(self) -> str:
@@ -32,6 +33,7 @@ class SourceAssertion:
             str(self.value),
             self.evidence.evidence_id,
             self.source_system,
+            self.transformation_event_id,
         )
 
 
@@ -41,20 +43,48 @@ def assertions_for_bom_line(
     quantity: Decimal,
     unit_price: Decimal | None,
     evidence: EvidenceRef,
+    transformation_event_id: str | None = None,
 ) -> tuple[SourceAssertion, ...]:
     assertions = (
-        SourceAssertion(sku, AssertionPredicate.HAS_SKU, sku, evidence),
-        SourceAssertion(sku, AssertionPredicate.HAS_DESCRIPTION, description, evidence),
-        SourceAssertion(sku, AssertionPredicate.HAS_QUANTITY, quantity, evidence),
+        SourceAssertion(
+            sku,
+            AssertionPredicate.HAS_SKU,
+            sku,
+            evidence,
+            transformation_event_id=transformation_event_id,
+        ),
+        SourceAssertion(
+            sku,
+            AssertionPredicate.HAS_DESCRIPTION,
+            description,
+            evidence,
+            transformation_event_id=transformation_event_id,
+        ),
+        SourceAssertion(
+            sku,
+            AssertionPredicate.HAS_QUANTITY,
+            quantity,
+            evidence,
+            transformation_event_id=transformation_event_id,
+        ),
     )
     if unit_price is None:
         return assertions
     return assertions + (
-        SourceAssertion(sku, AssertionPredicate.HAS_UNIT_PRICE, unit_price, evidence),
+        SourceAssertion(
+            sku,
+            AssertionPredicate.HAS_UNIT_PRICE,
+            unit_price,
+            evidence,
+            transformation_event_id=transformation_event_id,
+        ),
     )
 
 
-def assertions_for_bom(bom: Bom) -> tuple[SourceAssertion, ...]:
+def assertions_for_bom(
+    bom: Bom,
+    transformation_event_id: str | None = None,
+) -> tuple[SourceAssertion, ...]:
     assertions: list[SourceAssertion] = []
     for line in bom.lines:
         assertions.extend(
@@ -64,6 +94,7 @@ def assertions_for_bom(bom: Bom) -> tuple[SourceAssertion, ...]:
                 line.quantity,
                 line.unit_price,
                 line.evidence,
+                transformation_event_id,
             )
         )
     return tuple(assertions)

--- a/src/procurement_intelligence_lab/domain/provenance.py
+++ b/src/procurement_intelligence_lab/domain/provenance.py
@@ -1,4 +1,4 @@
-"""Immutable execution and decision provenance contracts."""
+"""Immutable execution, decision, and transformation provenance contracts."""
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -11,6 +11,16 @@ class ComponentKind(StrEnum):
     DETERMINISTIC = "deterministic"
     MODEL = "model"
     HUMAN = "human"
+
+
+class ProvenanceRelation(StrEnum):
+    DERIVED_FROM = "derived_from"
+    USED_INPUT = "used_input"
+    USED_SCHEMA = "used_schema"
+    USED_MODEL = "used_model"
+    SUPERSEDES = "supersedes"
+    REVIEWED_BY = "reviewed_by"
+    OVERRIDES = "overrides"
 
 
 @dataclass(frozen=True)
@@ -87,6 +97,44 @@ class DecisionProvenance:
             self.model_revision,
             self.prompt_version,
             self.schema_version,
+        )
+
+
+@dataclass(frozen=True)
+class ProvenanceEdge:
+    """A typed relationship from a transformation event to another durable ID."""
+
+    relation: ProvenanceRelation
+    target_id: str
+
+
+@dataclass(frozen=True)
+class TransformationEvent:
+    """Immutable event connecting a transformation to its inputs and outputs."""
+
+    event_type: str
+    provenance: DecisionProvenance
+    input_edges: tuple[ProvenanceEdge, ...]
+    output_ids: tuple[str, ...]
+    parent_event_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.event_type:
+            raise ValueError("event_type must not be empty")
+        if not self.output_ids:
+            raise ValueError("transformation events require at least one output")
+        if any(not edge.target_id for edge in self.input_edges):
+            raise ValueError("provenance edge targets must not be empty")
+
+    @property
+    def event_id(self) -> str:
+        return stable_id(
+            "transformation-event",
+            self.event_type,
+            self.provenance.provenance_id,
+            tuple((edge.relation.value, edge.target_id) for edge in self.input_edges),
+            self.output_ids,
+            self.parent_event_ids,
         )
 
 

--- a/tests/unit/test_provenance.py
+++ b/tests/unit/test_provenance.py
@@ -6,6 +6,9 @@ from procurement_intelligence_lab.domain.provenance import (
     ComponentKind,
     DecisionProvenance,
     ProvenanceContext,
+    ProvenanceEdge,
+    ProvenanceRelation,
+    TransformationEvent,
 )
 
 
@@ -53,3 +56,54 @@ def test_decision_provenance_links_component_to_execution_context() -> None:
 
     assert provenance.context.context_id == _context().context_id
     assert provenance.provenance_id.startswith("decision-provenance:")
+
+
+def test_transformation_event_identity_changes_with_implementation_version() -> None:
+    first = TransformationEvent(
+        "document-structuring",
+        DecisionProvenance(
+            _context(),
+            "xlsx-bom-structurer",
+            ComponentKind.DETERMINISTIC,
+            "1",
+            schema_version="bom-xlsx-v1",
+        ),
+        (ProvenanceEdge(ProvenanceRelation.USED_INPUT, "artifact:hash"),),
+        ("structured-bom:hash:BOM",),
+    )
+    second = TransformationEvent(
+        "document-structuring",
+        DecisionProvenance(
+            _context(),
+            "xlsx-bom-structurer",
+            ComponentKind.DETERMINISTIC,
+            "2",
+            schema_version="bom-xlsx-v1",
+        ),
+        (ProvenanceEdge(ProvenanceRelation.USED_INPUT, "artifact:hash"),),
+        ("structured-bom:hash:BOM",),
+    )
+
+    assert first.event_id != second.event_id
+
+
+def test_model_transformation_retains_resolved_model_and_schema_identity() -> None:
+    event = TransformationEvent(
+        "document-structuring",
+        DecisionProvenance(
+            _context(),
+            "model-structurer",
+            ComponentKind.MODEL,
+            "1",
+            model_provider="provider",
+            model_id="model",
+            model_revision="2026-01-01",
+            prompt_version="prompt-v1",
+            schema_version="bom-schema-v2",
+        ),
+        (ProvenanceEdge(ProvenanceRelation.USED_INPUT, "artifact:hash"),),
+        ("structured-bom:hash",),
+    )
+
+    assert event.provenance.model_revision == "2026-01-01"
+    assert event.provenance.schema_version == "bom-schema-v2"

--- a/tests/unit/test_xlsx_adapter.py
+++ b/tests/unit/test_xlsx_adapter.py
@@ -2,12 +2,15 @@ from decimal import Decimal
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile
 
-from procurement_intelligence_lab.adapters.xlsx import read_bom
+from procurement_intelligence_lab.adapters.xlsx import (
+    read_bom,
+    read_bom_with_provenance,
+)
 from procurement_intelligence_lab.domain.bom import bom_cost, gpu_quantity
+from procurement_intelligence_lab.domain.provenance import ProvenanceRelation
 
 
-def test_reads_synthetic_xlsx_with_cell_provenance(tmp_path: Path) -> None:
-    path = tmp_path / "bom.xlsx"
+def _write_bom(path: Path) -> None:
     content = '<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c><v>SKU</v></c><c><v>Description</v></c><c><v>Quantity</v></c><c><v>Unit Price</v></c></row><row r="2"><c><v>GPU-A</v></c><c><v>GPU accelerator</v></c><c><v>4</v></c><c><v>100</v></c></row></sheetData></worksheet>'
     workbook = '<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="BOM" sheetId="1" r:id="rId1"/></sheets></workbook>'
     rels = '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml"/></Relationships>'
@@ -15,7 +18,35 @@ def test_reads_synthetic_xlsx_with_cell_provenance(tmp_path: Path) -> None:
         archive.writestr("xl/workbook.xml", workbook)
         archive.writestr("xl/_rels/workbook.xml.rels", rels)
         archive.writestr("xl/worksheets/sheet1.xml", content)
+
+
+def test_reads_synthetic_xlsx_with_cell_provenance(tmp_path: Path) -> None:
+    path = tmp_path / "bom.xlsx"
+    _write_bom(path)
+
     bom = read_bom(path)
+
     assert gpu_quantity(bom).value == Decimal(4)
     assert bom_cost(bom).value == Decimal(400)
     assert bom.lines[0].evidence.row == 2
+
+
+def test_xlsx_structuring_records_event_and_carries_it_into_assertions(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "bom.xlsx"
+    _write_bom(path)
+
+    result = read_bom_with_provenance(path)
+    assertions = result.source_assertions()
+
+    assert result.transformation.provenance.component_name == "xlsx-bom-structurer"
+    assert result.transformation.provenance.schema_version == "bom-xlsx-v1"
+    assert any(
+        edge.relation is ProvenanceRelation.USED_INPUT
+        and edge.target_id == f"artifact:{result.bom.lines[0].evidence.content_hash}"
+        for edge in result.transformation.input_edges
+    )
+    assert {item.transformation_event_id for item in assertions} == {
+        result.transformation.event_id
+    }

--- a/tests/unit/test_xlsx_adapter.py
+++ b/tests/unit/test_xlsx_adapter.py
@@ -47,6 +47,4 @@ def test_xlsx_structuring_records_event_and_carries_it_into_assertions(
         and edge.target_id == f"artifact:{result.bom.lines[0].evidence.content_hash}"
         for edge in result.transformation.input_edges
     )
-    assert {item.transformation_event_id for item in assertions} == {
-        result.transformation.event_id
-    }
+    assert {item.transformation_event_id for item in assertions} == {result.transformation.event_id}


### PR DESCRIPTION
## Summary

Implements the first deterministic vertical slice for [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98):

- adds immutable transformation events with typed provenance relationships and optional parent events;
- records the XLSX structurer's source-artifact hash, implementation and schema identities, output ID, and execution context;
- carries the resulting event reference into source assertions while preserving the existing evidence reference;
- documents the DAG model and refreshes the project handoff after the retrieval-lifecycle merge.

This uses the repository as the durable interoperability layer for engineering decisions: it records compact, auditable metadata only—never raw prompts, secrets, hidden reasoning, or chat transcripts.

## Validation

- Added unit coverage for deterministic and model-capable provenance identities.
- Added an end-to-end XLSX-to-assertion provenance test.
- GitHub Actions will run the repository's full `make check` suite.

Closes #98.