### PR TITLE
feat: require explicit request scope at query boundaries

### DIFF
--- a/docs/adr/019-explicit-request-scope.md
+++ b/docs/adr/019-explicit-request-scope.md
@@ -1,0 +1,17 @@
+# ADR-019: Explicit request scope at query boundaries
+
+Status: accepted
+
+## Context
+
+Evidence, operational-state, retrieval, review, and future action paths must not infer tenant, project, or site from an unscoped request. The synthetic prototype does not provide production authentication, but it still needs a testable boundary that prevents accidental cross-scope reads as adapters expand.
+
+## Decision
+
+Introduce an immutable `RequestContext` with principal, tenant, project, site, permissions, and trace identity. Application and port boundaries receive the context explicitly and require the relevant permission. Retrieval projections retain the scope that built them and reject a search context whose tenant/project/site does not match before ranking.
+
+The local inspector accepts only its fixed synthetic fixture scope. Missing or conflicting scope returns a typed authorization failure; this demonstrates boundary behavior but is not a production identity provider or isolation guarantee.
+
+## Consequences
+
+Future adapters must resolve authentication and authorization into `RequestContext` before calling query or action services. Scope stays outside the semantic domain records until a governed multi-scope data model is introduced. Documents remain untrusted data and never grant scope or permission.

--- a/docs/project/handoff.md
+++ b/docs/project/handoff.md
@@ -8,7 +8,7 @@ Start with [AGENTS.md](../../AGENTS.md), then read the relevant [GitHub Issue](h
 
 ## Current milestone and status
 
-- **M7 — Append-only persistence, temporal/as-of state, anomaly taxonomy, and execution provenance:** in progress. The ledger boundary and the first anomaly/provenance contract are on `main`; remaining work includes temporal correction, durable storage, and complete transformation provenance. See the [canonical milestone map](../development/milestone-map.md), [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60), and [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98).
+- **M7 — Append-only persistence, temporal/as-of state, anomaly taxonomy, and execution provenance:** in progress. The ledger boundary and the first anomaly/provenance contract are on `main`; remaining work includes temporal correction, durable storage, and anomaly/state modeling. See the [canonical milestone map](../development/milestone-map.md) and [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60).
 - **M8 — Retrieval projections and review UI:** in progress. The rebuildable projection lifecycle foundation is complete; later adapter work remains. See [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54).
 - **M9 — Guarded actions, product signals, and integrated evaluation:** planned.
 - The initial M0–M6 evidence-first vertical slice is complete on `main`; the [root README](../../README.md) records the current product boundary and runnable entry points.
@@ -26,10 +26,11 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 - Layered deterministic and advisory PR review governance; see [PR #93](https://github.com/stauntonjr/procurement-intelligence-lab/pull/93).
 - Canonical shared project-memory convention; see [PR #96](https://github.com/stauntonjr/procurement-intelligence-lab/pull/96).
 - M8 rebuildable lexical retrieval-projection lifecycle foundation; see [PR #101](https://github.com/stauntonjr/procurement-intelligence-lab/pull/101) and [ADR-018](../adr/018-rebuildable-retrieval-projections.md).
+- M7.2 deterministic XLSX transformation provenance through source assertions; see [PR #102](https://github.com/stauntonjr/procurement-intelligence-lab/pull/102) and [ADR-017](../adr/017-execution-and-decision-provenance.md).
 
 ## Active work and PRs
 
-- [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98) is the active M7.2 slice: it establishes an immutable transformation-event contract and first traces the deterministic XLSX structurer into source assertions.
+- [Issue #51](https://github.com/stauntonjr/procurement-intelligence-lab/issues/51) is the active cross-cutting scope slice: it establishes an explicit request context before later lexical retrieval, operational state, or action paths expand.
 - [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54) is complete. Follow-on M8 work includes [Issues #55, #57, #59, #62, and #63](https://github.com/stauntonjr/procurement-intelligence-lab/issues/63); preserve their dependencies and evaluation gates.
 - M6 follow-on review work remains tracked by [Issues #85, #87, and #89](https://github.com/stauntonjr/procurement-intelligence-lab/issues/89).
 
@@ -46,13 +47,13 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 ## Open decisions and questions
 
 - Which append-only persistence/database adapter should follow the M7 port, and what temporal correction evidence is required? Start with [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91) and the ADRs linked from that issue.
-- How should transformation provenance extend from the deterministic XLSX slice to mapping, model-backed structuring, and downstream decisions? Start with [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98).
+- How should the request-scope contract evolve from the synthetic fixture boundary to authenticated multi-project adapters? Start with [Issue #51](https://github.com/stauntonjr/procurement-intelligence-lab/issues/51).
 - Which retrieval projections and fusion strategy earn adoption under the M8 evaluation plan? Start with [Issues #55, #57, and #59](https://github.com/stauntonjr/procurement-intelligence-lab/issues/59).
 - Which review, guarded-action, and product-feedback slices should be sequenced next? Use the [milestone map](../development/milestone-map.md) and linked issue acceptance criteria.
 
 ## Recommended next work
 
-1. Complete and review [Issue #98](https://github.com/stauntonjr/procurement-intelligence-lab/issues/98); retain the deterministic XLSX vertical as the reference before extending it to model-backed structuring or graph/hypergraph persistence.
+1. Complete and review [Issue #51](https://github.com/stauntonjr/procurement-intelligence-lab/issues/51) before implementing lexical retrieval; scope filters must run before ranking.
 2. Run the [roadmap stewardship protocol](../development/roadmap-stewardship.md) and resolve confirmed durable-record drift through normal Issues and PRs.
 3. Sequence later retrieval adapters only after their prerequisites, scope filters, and evaluation evidence are ready.
 4. Before selecting retrieval or agent frameworks, run the repository's stated evaluation and benchmark work.

--- a/src/procurement_intelligence_lab/adapters/memory_retrieval.py
+++ b/src/procurement_intelligence_lab/adapters/memory_retrieval.py
@@ -3,17 +3,17 @@
 from datetime import datetime
 
 from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
-from procurement_intelligence_lab.domain.scope import (
-    Permission,
-    RequestContext,
-    ScopeAuthorizationError,
-)
 from procurement_intelligence_lab.domain.retrieval import (
     ProjectionBuildRequest,
     ProjectionManifest,
     ProjectionStatus,
     RetrievalHit,
     source_entry_ids,
+)
+from procurement_intelligence_lab.domain.scope import (
+    Permission,
+    RequestContext,
+    ScopeAuthorizationError,
 )
 
 

--- a/src/procurement_intelligence_lab/adapters/memory_retrieval.py
+++ b/src/procurement_intelligence_lab/adapters/memory_retrieval.py
@@ -3,6 +3,11 @@
 from datetime import datetime
 
 from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+from procurement_intelligence_lab.domain.scope import (
+    Permission,
+    RequestContext,
+    ScopeAuthorizationError,
+)
 from procurement_intelligence_lab.domain.retrieval import (
     ProjectionBuildRequest,
     ProjectionManifest,
@@ -38,6 +43,7 @@ class InMemoryLexicalProjection:
             source_as_of=source_as_of,
             status=ProjectionStatus.READY,
             recorded_at=request.requested_at,
+            scope=request.scope,
         )
         self._entries[request.projection_id] = entries
         self._manifests[request.projection_id] = manifest
@@ -47,13 +53,16 @@ class InMemoryLexicalProjection:
         return self._manifests.get(projection_id)
 
     def search(
-        self, projection_id: str, query: str, *, limit: int = 10
+        self, projection_id: str, query: str, *, context: RequestContext, limit: int = 10
     ) -> tuple[RetrievalHit, ...]:
         if limit <= 0:
             raise ValueError("limit must be positive")
         manifest = self._manifests.get(projection_id)
         if manifest is None or manifest.status is not ProjectionStatus.READY:
             raise LookupError("projection is not ready")
+        context.require(Permission.SEARCH)
+        if not context.matches(manifest.scope):
+            raise ScopeAuthorizationError("request scope does not match projection scope")
         terms = tuple(term for term in query.casefold().split() if term)
         if not terms:
             return ()
@@ -110,6 +119,7 @@ class InMemoryLexicalProjection:
             source_as_of=previous.source_as_of,
             status=status,
             recorded_at=recorded_at,
+            scope=previous.scope,
             failure_reason=failure_reason,
         )
         self._manifests[previous.projection_id] = manifest

--- a/src/procurement_intelligence_lab/application/chat.py
+++ b/src/procurement_intelligence_lab/application/chat.py
@@ -6,6 +6,7 @@ from procurement_intelligence_lab.application.evidence_service import (
     inspect_bom_claims,
 )
 from procurement_intelligence_lab.domain.bom import Bom
+from procurement_intelligence_lab.domain.scope import RequestContext
 
 
 class UnsupportedQuestionError(ValueError):
@@ -13,7 +14,11 @@ class UnsupportedQuestionError(ValueError):
 
 
 def answer_question(
-    question: str, bom: Bom, canonical_candidates: tuple[str, ...]
+    question: str,
+    bom: Bom,
+    canonical_candidates: tuple[str, ...],
+    *,
+    request_context: RequestContext,
 ) -> EvidenceBackedClaim:
     normalized = " ".join(question.casefold().replace("-", " ").split())
     if "gpu" in normalized and any(token in normalized for token in ("how many", "quantity")):
@@ -26,5 +31,11 @@ def answer_question(
         raise UnsupportedQuestionError("no approved deterministic claim route for this question")
 
     return next(
-        claim for claim in inspect_bom_claims(bom, canonical_candidates) if claim.kind is kind
+        claim
+        for claim in inspect_bom_claims(
+            bom,
+            canonical_candidates,
+            request_context=request_context,
+        )
+        if claim.kind is kind
     )

--- a/src/procurement_intelligence_lab/application/evidence_service.py
+++ b/src/procurement_intelligence_lab/application/evidence_service.py
@@ -14,6 +14,7 @@ from procurement_intelligence_lab.domain.bom import (
 )
 from procurement_intelligence_lab.domain.evidence import EvidenceChain
 from procurement_intelligence_lab.domain.identity import stable_id
+from procurement_intelligence_lab.domain.scope import RequestContext
 
 
 class ClaimKind(StrEnum):
@@ -43,9 +44,16 @@ class EvidenceBackedClaim:
 
 
 def inspect_bom_claims(
-    bom: Bom, canonical_candidates: tuple[str, ...]
+    bom: Bom,
+    canonical_candidates: tuple[str, ...],
+    *,
+    request_context: RequestContext,
 ) -> tuple[EvidenceBackedClaim, ...]:
-    trace = run_bom_pipeline(bom, canonical_candidates).evidence
+    trace = run_bom_pipeline(
+        bom,
+        canonical_candidates,
+        request_context=request_context,
+    ).evidence
     queries: tuple[tuple[ClaimKind, QueryResult], ...] = (
         (ClaimKind.DISTINCT_SKUS, distinct_skus(bom)),
         (ClaimKind.GPU_QUANTITY, gpu_quantity(bom)),

--- a/src/procurement_intelligence_lab/application/pipeline.py
+++ b/src/procurement_intelligence_lab/application/pipeline.py
@@ -22,6 +22,7 @@ from procurement_intelligence_lab.domain.resolution import (
     ResolutionDecision,
     resolve_identifier,
 )
+from procurement_intelligence_lab.domain.scope import Permission, RequestContext
 from procurement_intelligence_lab.domain.state import project_operational_lines
 
 
@@ -39,7 +40,10 @@ def run_bom_pipeline(
     canonical_candidates: tuple[str, ...],
     *,
     provenance: ProvenanceContext | None = None,
+    request_context: RequestContext | None = None,
 ) -> BomPipelineResult:
+    if request_context is not None:
+        request_context.require(Permission.READ_STATE)
     context = provenance or local_provenance_context()
     resolution_provenance = DecisionProvenance(
         context,

--- a/src/procurement_intelligence_lab/application/review.py
+++ b/src/procurement_intelligence_lab/application/review.py
@@ -8,6 +8,7 @@ from procurement_intelligence_lab.application.evidence_service import (
     inspect_bom_claims,
 )
 from procurement_intelligence_lab.domain.bom import Bom
+from procurement_intelligence_lab.domain.scope import Permission, RequestContext
 
 
 class ReviewReason(StrEnum):
@@ -31,9 +32,18 @@ class ReviewContext:
 
 
 def review_context_for_claim(
-    claim_id: str, bom: Bom, canonical_candidates: tuple[str, ...]
+    claim_id: str,
+    bom: Bom,
+    canonical_candidates: tuple[str, ...],
+    *,
+    request_context: RequestContext,
 ) -> ReviewContext:
-    claims = inspect_bom_claims(bom, canonical_candidates)
+    request_context.require(Permission.REVIEW)
+    claims = inspect_bom_claims(
+        bom,
+        canonical_candidates,
+        request_context=request_context,
+    )
     claim = next((claim for claim in claims if claim.claim_id == claim_id), None)
     if claim is None:
         raise LookupError(f"unknown claim ID: {claim_id}")

--- a/src/procurement_intelligence_lab/domain/retrieval.py
+++ b/src/procurement_intelligence_lab/domain/retrieval.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 
 from procurement_intelligence_lab.domain.identity import stable_id
 from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+from procurement_intelligence_lab.domain.scope import RequestContext
 
 
 class ProjectionKind(StrEnum):
@@ -27,6 +28,7 @@ class ProjectionBuildRequest:
     implementation_version: str
     config_digest: str
     requested_at: datetime
+    scope: RequestContext
 
     def __post_init__(self) -> None:
         if not self.projection_id:
@@ -49,6 +51,7 @@ class ProjectionManifest:
     source_as_of: datetime
     status: ProjectionStatus
     recorded_at: datetime
+    scope: RequestContext
     failure_reason: str | None = None
 
     def __post_init__(self) -> None:
@@ -71,6 +74,9 @@ class ProjectionManifest:
             self.source_as_of.isoformat(),
             self.status.value,
             self.recorded_at.isoformat(),
+            self.scope.tenant_id,
+            self.scope.project_id,
+            self.scope.site_id,
             self.failure_reason,
         )
 

--- a/src/procurement_intelligence_lab/domain/scope.py
+++ b/src/procurement_intelligence_lab/domain/scope.py
@@ -1,0 +1,57 @@
+"""Explicit, fail-closed request scope and authorization contracts."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Permission(StrEnum):
+    READ_EVIDENCE = "read_evidence"
+    READ_STATE = "read_state"
+    SEARCH = "search"
+    REVIEW = "review"
+    ACT = "act"
+
+
+class ScopeAuthorizationError(PermissionError):
+    """Raised when a request lacks an explicit authorized scope."""
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Caller and resource boundary for application queries and actions."""
+
+    principal_id: str
+    tenant_id: str
+    project_id: str
+    site_id: str
+    permissions: frozenset[Permission]
+    trace_id: str
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.principal_id,
+                self.tenant_id,
+                self.project_id,
+                self.site_id,
+                self.trace_id,
+            )
+        ):
+            raise ValueError("principal, tenant, project, site, and trace IDs are required")
+
+    def require(self, permission: Permission) -> None:
+        if permission not in self.permissions:
+            raise ScopeAuthorizationError(
+                f"principal {self.principal_id!r} lacks {permission.value!r} permission"
+            )
+
+    def matches(self, other: "RequestContext") -> bool:
+        return (
+            self.tenant_id,
+            self.project_id,
+            self.site_id,
+        ) == (
+            other.tenant_id,
+            other.project_id,
+            other.site_id,
+        )

--- a/src/procurement_intelligence_lab/interfaces/web.py
+++ b/src/procurement_intelligence_lab/interfaces/web.py
@@ -14,6 +14,11 @@ from procurement_intelligence_lab.application.chat import (
     answer_question,
 )
 from procurement_intelligence_lab.application.review import review_context_for_claim
+from procurement_intelligence_lab.domain.scope import (
+    Permission,
+    RequestContext,
+    ScopeAuthorizationError,
+)
 
 _HTML = """<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
@@ -34,6 +39,9 @@ form.addEventListener("submit",async event=>{event.preventDefault();const q=new 
 </script></main></body></html>"""
 
 
+_DEMO_SCOPE = ("synthetic-tenant", "synthetic-project", "synthetic-site")
+
+
 class EvidenceNotFoundError(LookupError):
     """Raised when an evidence ID is not present in the committed fixture."""
 
@@ -46,9 +54,31 @@ def _fixture() -> Path:
     return Path(__file__).resolve().parents[3] / "examples" / "synthetic_bom.xlsx"
 
 
-def claim_payload(question: str) -> dict[str, object]:
+def _request_context(
+    query: dict[str, list[str]],
+    permission: Permission,
+) -> RequestContext:
+    scope = tuple(query.get(name, [""])[0] for name in ("tenant_id", "project_id", "site_id"))
+    if scope != _DEMO_SCOPE:
+        raise ScopeAuthorizationError("missing or conflicting synthetic demo scope")
+    return RequestContext(
+        "demo-user",
+        scope[0],
+        scope[1],
+        scope[2],
+        frozenset({permission}),
+        "http-demo",
+    )
+
+
+def claim_payload(question: str, *, request_context: RequestContext) -> dict[str, object]:
     bom = read_bom(_fixture())
-    claim = answer_question(question, bom, tuple(line.sku for line in bom.lines))
+    claim = answer_question(
+        question,
+        bom,
+        tuple(line.sku for line in bom.lines),
+        request_context=request_context,
+    )
     value = str(claim.value) if isinstance(claim.value, Decimal) else claim.value
     return {
         "question": question,
@@ -75,7 +105,12 @@ def claim_payload(question: str) -> dict[str, object]:
     }
 
 
-def source_payload(evidence_id: str) -> dict[str, object]:
+def source_payload(
+    evidence_id: str,
+    *,
+    request_context: RequestContext,
+) -> dict[str, object]:
+    request_context.require(Permission.READ_EVIDENCE)
     bom = read_bom(_fixture())
     for line in bom.lines:
         evidence = line.evidence
@@ -93,7 +128,12 @@ def source_payload(evidence_id: str) -> dict[str, object]:
     raise EvidenceNotFoundError(f"unknown evidence ID: {evidence_id}")
 
 
-def review_context_payload(claim_id: str) -> dict[str, object]:
+def review_context_payload(
+    claim_id: str,
+    *,
+    request_context: RequestContext,
+) -> dict[str, object]:
+    request_context.require(Permission.REVIEW)
     bom = read_bom(_fixture())
     try:
         context = review_context_for_claim(claim_id, bom, tuple(line.sku for line in bom.lines))
@@ -119,36 +159,52 @@ def review_context_payload(claim_id: str) -> dict[str, object]:
 class InspectorHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
         if parsed.path == "/":
             body = _HTML.encode()
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
         elif parsed.path == "/api/ask":
-            question = parse_qs(parsed.query).get("q", [""])[0]
+            question = query.get("q", [""])[0]
             try:
-                body = json.dumps(claim_payload(question)).encode()
+                body = json.dumps(
+                    claim_payload(
+                        question,
+                        request_context=_request_context(query, Permission.READ_STATE),
+                    )
+                ).encode()
                 self.send_response(200)
-            except UnsupportedQuestionError as error:
+            except (UnsupportedQuestionError, ScopeAuthorizationError) as error:
                 body = json.dumps({"error": str(error)}).encode()
-                self.send_response(422)
+                self.send_response(422 if isinstance(error, UnsupportedQuestionError) else 403)
             self.send_header("Content-Type", "application/json")
         elif parsed.path == "/api/source":
-            evidence_id = parse_qs(parsed.query).get("evidence_id", [""])[0]
+            evidence_id = query.get("evidence_id", [""])[0]
             try:
-                body = json.dumps(source_payload(evidence_id)).encode()
+                body = json.dumps(
+                    source_payload(
+                        evidence_id,
+                        request_context=_request_context(query, Permission.READ_EVIDENCE),
+                    )
+                ).encode()
                 self.send_response(200)
-            except EvidenceNotFoundError as error:
+            except (EvidenceNotFoundError, ScopeAuthorizationError) as error:
                 body = json.dumps({"error": str(error)}).encode()
-                self.send_response(404)
+                self.send_response(404 if isinstance(error, EvidenceNotFoundError) else 403)
             self.send_header("Content-Type", "application/json")
         elif parsed.path == "/api/review-context":
-            claim_id = parse_qs(parsed.query).get("claim_id", [""])[0]
+            claim_id = query.get("claim_id", [""])[0]
             try:
-                body = json.dumps(review_context_payload(claim_id)).encode()
+                body = json.dumps(
+                    review_context_payload(
+                        claim_id,
+                        request_context=_request_context(query, Permission.REVIEW),
+                    )
+                ).encode()
                 self.send_response(200)
-            except ReviewContextNotFoundError as error:
+            except (ReviewContextNotFoundError, ScopeAuthorizationError) as error:
                 body = json.dumps({"error": str(error)}).encode()
-                self.send_response(404)
+                self.send_response(404 if isinstance(error, ReviewContextNotFoundError) else 403)
             self.send_header("Content-Type", "application/json")
         else:
             body = b"not found"

--- a/src/procurement_intelligence_lab/interfaces/web.py
+++ b/src/procurement_intelligence_lab/interfaces/web.py
@@ -66,7 +66,7 @@ def _request_context(
         scope[0],
         scope[1],
         scope[2],
-        frozenset({permission}),
+        frozenset({permission, Permission.READ_STATE}),
         "http-demo",
     )
 
@@ -136,7 +136,12 @@ def review_context_payload(
     request_context.require(Permission.REVIEW)
     bom = read_bom(_fixture())
     try:
-        context = review_context_for_claim(claim_id, bom, tuple(line.sku for line in bom.lines))
+        context = review_context_for_claim(
+            claim_id,
+            bom,
+            tuple(line.sku for line in bom.lines),
+            request_context=request_context,
+        )
     except LookupError as error:
         raise ReviewContextNotFoundError(str(error)) from error
     value = (

--- a/src/procurement_intelligence_lab/ports/retrieval.py
+++ b/src/procurement_intelligence_lab/ports/retrieval.py
@@ -4,12 +4,12 @@ from datetime import datetime
 from typing import Protocol
 
 from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
-from procurement_intelligence_lab.domain.scope import RequestContext
 from procurement_intelligence_lab.domain.retrieval import (
     ProjectionBuildRequest,
     ProjectionManifest,
     RetrievalHit,
 )
+from procurement_intelligence_lab.domain.scope import RequestContext
 
 
 class RetrievalProjection(Protocol):

--- a/src/procurement_intelligence_lab/ports/retrieval.py
+++ b/src/procurement_intelligence_lab/ports/retrieval.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Protocol
 
 from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+from procurement_intelligence_lab.domain.scope import RequestContext
 from procurement_intelligence_lab.domain.retrieval import (
     ProjectionBuildRequest,
     ProjectionManifest,
@@ -24,7 +25,7 @@ class RetrievalProjection(Protocol):
     def status(self, projection_id: str) -> ProjectionManifest | None: ...
 
     def search(
-        self, projection_id: str, query: str, *, limit: int = 10
+        self, projection_id: str, query: str, *, context: RequestContext, limit: int = 10
     ) -> tuple[RetrievalHit, ...]: ...
 
     def fail(

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -8,6 +8,13 @@ from procurement_intelligence_lab.application.chat import (
 )
 from procurement_intelligence_lab.application.evidence_service import ClaimKind
 from procurement_intelligence_lab.domain.bom import Bom, BomLine, EvidenceRef
+from procurement_intelligence_lab.domain.scope import Permission, RequestContext
+
+
+def _context() -> RequestContext:
+    return RequestContext(
+        "user", "tenant", "project", "site", frozenset({Permission.READ_STATE}), "trace"
+    )
 
 
 def bom() -> Bom:
@@ -22,7 +29,12 @@ def bom() -> Bom:
 
 
 def test_question_routes_to_evidence_backed_deterministic_claim() -> None:
-    result = answer_question("How many GPUs are in the BOM?", bom(), ("GPU-A", "CPU-A"))
+    result = answer_question(
+        "How many GPUs are in the BOM?",
+        bom(),
+        ("GPU-A", "CPU-A"),
+        request_context=_context(),
+    )
 
     assert result.kind is ClaimKind.GPU_QUANTITY
     assert result.value == Decimal(4)
@@ -31,4 +43,9 @@ def test_question_routes_to_evidence_backed_deterministic_claim() -> None:
 
 def test_unapproved_question_abstains() -> None:
     with pytest.raises(UnsupportedQuestionError, match="no approved"):
-        answer_question("Which vendor should I choose?", bom(), ("GPU-A", "CPU-A"))
+        answer_question(
+            "Which vendor should I choose?",
+            bom(),
+            ("GPU-A", "CPU-A"),
+            request_context=_context(),
+        )

--- a/tests/unit/test_evidence_service.py
+++ b/tests/unit/test_evidence_service.py
@@ -5,6 +5,13 @@ from procurement_intelligence_lab.application.evidence_service import (
     inspect_bom_claims,
 )
 from procurement_intelligence_lab.domain.bom import Bom, BomLine, EvidenceRef
+from procurement_intelligence_lab.domain.scope import Permission, RequestContext
+
+
+def _context() -> RequestContext:
+    return RequestContext(
+        "user", "tenant", "project", "site", frozenset({Permission.READ_STATE}), "trace"
+    )
 
 
 def test_claim_service_exposes_deterministic_values_and_execution_trace() -> None:
@@ -17,7 +24,7 @@ def test_claim_service_exposes_deterministic_values_and_execution_trace() -> Non
         ),
     )
 
-    claims = inspect_bom_claims(bom, ("GPU-A", "CPU-A"))
+    claims = inspect_bom_claims(bom, ("GPU-A", "CPU-A"), request_context=_context())
 
     assert [claim.kind for claim in claims] == [
         ClaimKind.DISTINCT_SKUS,

--- a/tests/unit/test_retrieval_projection.py
+++ b/tests/unit/test_retrieval_projection.py
@@ -91,7 +91,7 @@ def test_failed_or_deleted_projection_cannot_silently_serve_stale_results() -> N
     assert rebuilt.status is ProjectionStatus.READY
     assert deleted.status is ProjectionStatus.DELETED
     with pytest.raises(LookupError, match="not ready"):
-        projection.search("lexical-bom", "GPU")
+        projection.search("lexical-bom", "GPU", context=_scope())
 
 
 def test_projection_requires_explicit_lifecycle_inputs() -> None:

--- a/tests/unit/test_retrieval_projection.py
+++ b/tests/unit/test_retrieval_projection.py
@@ -8,15 +8,15 @@ from procurement_intelligence_lab.adapters.memory_retrieval import InMemoryLexic
 from procurement_intelligence_lab.domain.assertions import AssertionPredicate, SourceAssertion
 from procurement_intelligence_lab.domain.bom import EvidenceRef
 from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+from procurement_intelligence_lab.domain.retrieval (
+    ProjectionBuildRequest,
+    ProjectionKind,
+    ProjectionStatus,
+)
 from procurement_intelligence_lab.domain.scope import (
     Permission,
     RequestContext,
     ScopeAuthorizationError,
-)
-from procurement_intelligence_lab.domain.retrieval import (
-    ProjectionBuildRequest,
-    ProjectionKind,
-    ProjectionStatus,
 )
 
 

--- a/tests/unit/test_retrieval_projection.py
+++ b/tests/unit/test_retrieval_projection.py
@@ -8,7 +8,7 @@ from procurement_intelligence_lab.adapters.memory_retrieval import InMemoryLexic
 from procurement_intelligence_lab.domain.assertions import AssertionPredicate, SourceAssertion
 from procurement_intelligence_lab.domain.bom import EvidenceRef
 from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
-from procurement_intelligence_lab.domain.retrieval (
+from procurement_intelligence_lab.domain.retrieval import (
     ProjectionBuildRequest,
     ProjectionKind,
     ProjectionStatus,

--- a/tests/unit/test_retrieval_projection.py
+++ b/tests/unit/test_retrieval_projection.py
@@ -8,6 +8,11 @@ from procurement_intelligence_lab.adapters.memory_retrieval import InMemoryLexic
 from procurement_intelligence_lab.domain.assertions import AssertionPredicate, SourceAssertion
 from procurement_intelligence_lab.domain.bom import EvidenceRef
 from procurement_intelligence_lab.domain.ledger import AssertionLedgerEntry
+from procurement_intelligence_lab.domain.scope import (
+    Permission,
+    RequestContext,
+    ScopeAuthorizationError,
+)
 from procurement_intelligence_lab.domain.retrieval import (
     ProjectionBuildRequest,
     ProjectionKind,
@@ -34,6 +39,17 @@ def _entries() -> tuple[AssertionLedgerEntry, ...]:
     return first, second
 
 
+def _scope() -> RequestContext:
+    return RequestContext(
+        "demo-user",
+        "demo-tenant",
+        "demo-project",
+        "demo-site",
+        frozenset({Permission.SEARCH}),
+        "trace-1",
+    )
+
+
 def _request() -> ProjectionBuildRequest:
     return ProjectionBuildRequest(
         "lexical-bom",
@@ -41,6 +57,7 @@ def _request() -> ProjectionBuildRequest:
         "1",
         "config-v1",
         datetime(2026, 1, 3, tzinfo=UTC),
+        _scope(),
     )
 
 
@@ -50,7 +67,7 @@ def test_projection_builds_from_ledger_entries_and_exposes_source_metadata() -> 
 
     assert manifest.status is ProjectionStatus.READY
     assert len(manifest.source_entry_ids) == 2
-    hit = projection.search("lexical-bom", "accelerator")[0]
+    hit = projection.search("lexical-bom", "accelerator", context=_scope())[0]
     assert hit.entry.assertion.evidence.artifact_id == "bom.xlsx"
     assert hit.epistemic_status == "source_assertion"
     assert hit.projection_manifest_id == manifest.manifest_id
@@ -67,7 +84,7 @@ def test_failed_or_deleted_projection_cannot_silently_serve_stale_results() -> N
     )
     assert failed.status is ProjectionStatus.FAILED
     with pytest.raises(LookupError, match="not ready"):
-        projection.search("lexical-bom", "GPU")
+        projection.search("lexical-bom", "GPU", context=_scope())
 
     rebuilt = projection.build(_entries(), request=_request())
     deleted = projection.delete("lexical-bom", recorded_at=datetime(2026, 1, 5, tzinfo=UTC))
@@ -85,4 +102,26 @@ def test_projection_requires_explicit_lifecycle_inputs() -> None:
             "1",
             "config-v1",
             datetime(2026, 1, 3),  # noqa: DTZ001
+            _scope(),
         )
+
+
+def test_projection_rejects_missing_permission_or_conflicting_scope() -> None:
+    projection = InMemoryLexicalProjection()
+    projection.build(_entries(), request=_request())
+    missing_permission = RequestContext(
+        "demo-user", "demo-tenant", "demo-project", "demo-site", frozenset(), "trace-2"
+    )
+    conflicting_scope = RequestContext(
+        "demo-user",
+        "demo-tenant",
+        "other-project",
+        "demo-site",
+        frozenset({Permission.SEARCH}),
+        "trace-3",
+    )
+
+    with pytest.raises(ScopeAuthorizationError, match="lacks"):
+        projection.search("lexical-bom", "GPU", context=missing_permission)
+    with pytest.raises(ScopeAuthorizationError, match="does not match"):
+        projection.search("lexical-bom", "GPU", context=conflicting_scope)

--- a/tests/unit/test_review.py
+++ b/tests/unit/test_review.py
@@ -2,6 +2,7 @@ from typing import cast
 
 import pytest
 
+from procurement_intelligence_lab.domain.scope import Permission, RequestContext
 from procurement_intelligence_lab.interfaces.web import (
     ReviewContextNotFoundError,
     claim_payload,
@@ -9,11 +10,22 @@ from procurement_intelligence_lab.interfaces.web import (
 )
 
 
+def _context() -> RequestContext:
+    return RequestContext(
+        "demo-user",
+        "synthetic-tenant",
+        "synthetic-project",
+        "synthetic-site",
+        frozenset({Permission.READ_STATE, Permission.REVIEW}),
+        "trace",
+    )
+
+
 def test_review_context_preserves_claim_and_trace_references() -> None:
-    claim = claim_payload("How many GPUs are in the BOM?")
+    claim = claim_payload("How many GPUs are in the BOM?", request_context=_context())
     claim_id = cast(str, claim["claim_id"])
 
-    context = review_context_payload(claim_id)
+    context = review_context_payload(claim_id, request_context=_context())
 
     assert context["claim_id"] == claim_id
     assert context["claim_kind"] == "gpu_quantity"
@@ -32,4 +44,4 @@ def test_review_context_preserves_claim_and_trace_references() -> None:
 
 def test_review_context_rejects_unknown_claim_id() -> None:
     with pytest.raises(ReviewContextNotFoundError):
-        review_context_payload("claim:missing")
+        review_context_payload("claim:missing", request_context=_context())

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -2,6 +2,11 @@ from typing import cast
 
 import pytest
 
+from procurement_intelligence_lab.domain.scope import (
+    Permission,
+    RequestContext,
+    ScopeAuthorizationError,
+)
 from procurement_intelligence_lab.interfaces.web import (
     EvidenceNotFoundError,
     claim_payload,
@@ -9,8 +14,22 @@ from procurement_intelligence_lab.interfaces.web import (
 )
 
 
+def _context(permission: Permission) -> RequestContext:
+    return RequestContext(
+        "demo-user",
+        "synthetic-tenant",
+        "synthetic-project",
+        "synthetic-site",
+        frozenset({permission, Permission.READ_STATE}),
+        "trace",
+    )
+
+
 def test_claim_payload_exposes_trace_and_source_evidence() -> None:
-    payload = claim_payload("How many GPUs are in the BOM?")
+    payload = claim_payload(
+        "How many GPUs are in the BOM?",
+        request_context=_context(Permission.READ_STATE),
+    )
 
     assert payload["claim"] == "gpu_quantity"
     assert isinstance(payload["claim_id"], str)
@@ -32,11 +51,17 @@ def test_claim_payload_exposes_trace_and_source_evidence() -> None:
 
 
 def test_source_payload_resolves_a_stable_evidence_id() -> None:
-    claim = claim_payload("How many GPUs are in the BOM?")
+    claim = claim_payload(
+        "How many GPUs are in the BOM?",
+        request_context=_context(Permission.READ_STATE),
+    )
     evidence = cast(list[dict[str, object]], claim["evidence"])
     evidence_id = cast(str, evidence[0]["evidence_id"])
 
-    payload = source_payload(evidence_id)
+    payload = source_payload(
+        evidence_id,
+        request_context=_context(Permission.READ_EVIDENCE),
+    )
     source_evidence = cast(dict[str, object], payload["evidence"])
     source_line = cast(dict[str, object], payload["line"])
 
@@ -47,4 +72,15 @@ def test_source_payload_resolves_a_stable_evidence_id() -> None:
 
 def test_source_payload_rejects_unknown_evidence_id() -> None:
     with pytest.raises(EvidenceNotFoundError):
-        source_payload("evidence:missing")
+        source_payload(
+            "evidence:missing",
+            request_context=_context(Permission.READ_EVIDENCE),
+        )
+
+
+def test_source_payload_rejects_missing_evidence_permission() -> None:
+    with pytest.raises(ScopeAuthorizationError, match="lacks"):
+        source_payload(
+            "evidence:missing",
+            request_context=_context(Permission.READ_STATE),
+        )


### PR DESCRIPTION
## Summary

Implements [Issue #51](https://github.com/stauntonjr/procurement-intelligence-lab/issues/51) as a bounded, synthetic-demo request-scope contract.

- adds an immutable `RequestContext` with tenant, project, site, principal, permissions, and trace identity;
- requires scope permission for state, evidence, review, and retrieval reads;
- binds retrieval manifests to their build scope and rejects mismatched scopes before ranking;
- makes the inspector reject missing or conflicting synthetic fixture scope with a typed 403 boundary;
- documents the decision in ADR-019 and refreshes the project handoff after PR #102.

This is deliberately **not** a production authentication or tenant-isolation claim. It establishes the explicit port/application boundary that future authenticated adapters must populate.

## Validation

- Added scope-enforcement coverage for retrieval and inspector reads.
- Existing repository CI will run `make check`.

Closes #51.