### PR TITLE
feat: separate expected and observed procurement state

### DIFF
--- a/docs/adr/020-expected-observed-state.md
+++ b/docs/adr/020-expected-observed-state.md
@@ -1,0 +1,22 @@
+# ADR-020: Govern expected and observed procurement state separately
+
+Status: accepted
+
+## Context
+
+The existing operational projection captured only resolved BOM lines. It could not distinguish a requirement from an order, receipt, substitution, delay, partial observation, or missing observation. Anomaly detection needs explicit comparable state rather than inferring it from raw lines.
+
+## Decision
+
+Model expected requirements and observed procurement records as separate immutable projections.
+
+- `StateScope` binds each record to tenant, project, site, and BOM revision.
+- `ExpectedRequirement` records required quantity, as-of timestamp, and source evidence.
+- `ObservedProcurement` records ordered, received, substituted, delayed, and unknown quantities, freshness, as-of timestamp, and evidence.
+- `ExpectedObservedState` pairs the two projections and deterministically exposes outstanding quantity and observation freshness.
+
+This is a governed projection, not canonical source truth. It does not perform anomaly detection, prediction, or external integration. Those concerns remain separate slices.
+
+## Consequences
+
+Deterministic anomaly detection can compare explicit expected and observed inputs while preserving scope, evidence, and as-of context. Future adapters must populate observed records through scoped, append-oriented inputs; they may not infer authorization or source evidence from untrusted documents.

--- a/docs/development/milestone-map.md
+++ b/docs/development/milestone-map.md
@@ -11,7 +11,7 @@ This is the canonical map from the current implementation to the architecture. M
 | M4 | Constrained deterministic chat routing | Complete | `application/chat.py` |
 | M5 | Local HTTP chat/evidence inspector | Complete | [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82) |
 | M6 | Durable identifiers, source viewer, and review context | Complete | [PRs #86, #88, and #90](https://github.com/stauntonjr/procurement-intelligence-lab/pull/90), ADRs 013–014 |
-| M7 | Append-only persistence, temporal state, anomaly taxonomy, and execution provenance | In progress | [PR #92](https://github.com/stauntonjr/procurement-intelligence-lab/pull/92), [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60), ADRs 015–017 |
+| M7 | Append-only persistence, temporal state, anomaly taxonomy, and execution provenance | In progress | [PR #92](https://github.com/stauntonjr/procurement-intelligence-lab/pull/92), [Issues #47 and #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47), ADRs 015–017 and 020 |
 | M8 | Retrieval projections and review UI | In progress | Issue #54, ADR-018, retrieval lifecycle contract |
 | M9 | Guarded actions, product signals, and integrated evaluation | Planned | Approval gates, sanitized feedback loop, release evidence |
 

--- a/docs/development/milestone-map.md
+++ b/docs/development/milestone-map.md
@@ -11,7 +11,7 @@ This is the canonical map from the current implementation to the architecture. M
 | M4 | Constrained deterministic chat routing | Complete | `application/chat.py` |
 | M5 | Local HTTP chat/evidence inspector | Complete | [PR #82](https://github.com/stauntonjr/procurement-intelligence-lab/pull/82) |
 | M6 | Durable identifiers, source viewer, and review context | Complete | [PRs #86, #88, and #90](https://github.com/stauntonjr/procurement-intelligence-lab/pull/90), ADRs 013–014 |
-| M7 | Append-only persistence, temporal state, anomaly taxonomy, and execution provenance | In progress | [PR #92](https://github.com/stauntonjr/procurement-intelligence-lab/pull/92), [Issues #47 and #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47), ADRs 015–017 and 020 |
+| M7 | Append-only persistence, temporal state, anomaly taxonomy, and execution provenance | In progress | [PR #92](https://github.com/stauntonjr/procurement-intelligence-lab/pull/92), [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47), [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60), ADRs 015–017 and 020 |
 | M8 | Retrieval projections and review UI | In progress | Issue #54, ADR-018, retrieval lifecycle contract |
 | M9 | Guarded actions, product signals, and integrated evaluation | Planned | Approval gates, sanitized feedback loop, release evidence |
 

--- a/docs/project/handoff.md
+++ b/docs/project/handoff.md
@@ -8,7 +8,7 @@ Start with [AGENTS.md](../../AGENTS.md), then read the relevant [GitHub Issue](h
 
 ## Current milestone and status
 
-- **M7 — Append-only persistence, temporal/as-of state, anomaly taxonomy, and execution provenance:** in progress. The ledger boundary and the first anomaly/provenance contract are on `main`; remaining work includes temporal correction, durable storage, and anomaly/state modeling. See the [canonical milestone map](../development/milestone-map.md) and [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60).
+- **M7 — Append-only persistence, temporal/as-of state, anomaly taxonomy, and execution provenance:** in progress. The ledger boundary and the first anomaly/provenance contract are on `main`; remaining work includes expected-versus-observed state, temporal correction, durable storage, and anomaly orchestration. See the [canonical milestone map](../development/milestone-map.md), [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47), and [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60).
 - **M8 — Retrieval projections and review UI:** in progress. The rebuildable projection lifecycle foundation is complete; later adapter work remains. See [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54).
 - **M9 — Guarded actions, product signals, and integrated evaluation:** planned.
 - The initial M0–M6 evidence-first vertical slice is complete on `main`; the [root README](../../README.md) records the current product boundary and runnable entry points.
@@ -30,9 +30,9 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 
 ## Active work and PRs
 
-- [Issue #51](https://github.com/stauntonjr/procurement-intelligence-lab/issues/51) is the active cross-cutting scope slice: it establishes an explicit request context before later lexical retrieval, operational state, or action paths expand.
+- [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47) is the active state slice: it separates scoped expected requirements from observed procurement state before anomaly orchestration.
 - [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54) is complete. Follow-on M8 work includes [Issues #55, #57, #59, #62, and #63](https://github.com/stauntonjr/procurement-intelligence-lab/issues/63); preserve their dependencies and evaluation gates.
-- M6 follow-on review work remains tracked by [Issues #85, #87, and #89](https://github.com/stauntonjr/procurement-intelligence-lab/issues/89).
+- M6 identity, source-viewer, and review-context work is complete; see [Issues #85, #87, and #89](https://github.com/stauntonjr/procurement-intelligence-lab/issues/89).
 
 ## Settled decisions
 
@@ -46,14 +46,14 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 
 ## Open decisions and questions
 
-- Which append-only persistence/database adapter should follow the M7 port, and what temporal correction evidence is required? Start with [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91) and the ADRs linked from that issue.
-- How should the request-scope contract evolve from the synthetic fixture boundary to authenticated multi-project adapters? Start with [Issue #51](https://github.com/stauntonjr/procurement-intelligence-lab/issues/51).
+- How should scoped expected and observed procurement records be populated from append-only inputs, and what temporal correction evidence is required? Start with [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47) and [Issue #91](https://github.com/stauntonjr/procurement-intelligence-lab/issues/91).
+- How should the request-scope contract evolve from the synthetic fixture boundary to authenticated multi-project adapters? See [ADR-019](../adr/019-explicit-request-scope.md).
 - Which retrieval projections and fusion strategy earn adoption under the M8 evaluation plan? Start with [Issues #55, #57, and #59](https://github.com/stauntonjr/procurement-intelligence-lab/issues/59).
 - Which review, guarded-action, and product-feedback slices should be sequenced next? Use the [milestone map](../development/milestone-map.md) and linked issue acceptance criteria.
 
 ## Recommended next work
 
-1. Complete and review [Issue #51](https://github.com/stauntonjr/procurement-intelligence-lab/issues/51) before implementing lexical retrieval; scope filters must run before ranking.
+1. Complete and review [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47) before extending anomaly orchestration; expected and observed state must remain explicit and scoped.
 2. Run the [roadmap stewardship protocol](../development/roadmap-stewardship.md) and resolve confirmed durable-record drift through normal Issues and PRs.
 3. Sequence later retrieval adapters only after their prerequisites, scope filters, and evaluation evidence are ready.
 4. Before selecting retrieval or agent frameworks, run the repository's stated evaluation and benchmark work.

--- a/src/procurement_intelligence_lab/domain/state.py
+++ b/src/procurement_intelligence_lab/domain/state.py
@@ -142,9 +142,18 @@ def compare_expected_observed(
 ) -> tuple[ExpectedObservedState, ...]:
     if as_of.tzinfo is None:
         raise ValueError("as_of must be timezone-aware")
-    observed_by_key = {item.canonical_key: item for item in observed if item.as_of <= as_of}
+
+    observed_by_key: dict[tuple[StateScope, str], ObservedProcurement] = {}
+    for item in observed:
+        if item.as_of > as_of:
+            continue
+        key = (item.scope, item.canonical_key)
+        current = observed_by_key.get(key)
+        if current is None or item.as_of > current.as_of:
+            observed_by_key[key] = item
+
     return tuple(
-        ExpectedObservedState(item, observed_by_key.get(item.canonical_key))
+        ExpectedObservedState(item, observed_by_key.get((item.scope, item.canonical_key)))
         for item in expected
         if item.as_of <= as_of
     )

--- a/src/procurement_intelligence_lab/domain/state.py
+++ b/src/procurement_intelligence_lab/domain/state.py
@@ -142,9 +142,7 @@ def compare_expected_observed(
 ) -> tuple[ExpectedObservedState, ...]:
     if as_of.tzinfo is None:
         raise ValueError("as_of must be timezone-aware")
-    observed_by_key = {
-        item.canonical_key: item for item in observed if item.as_of <= as_of
-    }
+    observed_by_key = {item.canonical_key: item for item in observed if item.as_of <= as_of}
     return tuple(
         ExpectedObservedState(item, observed_by_key.get(item.canonical_key))
         for item in expected

--- a/src/procurement_intelligence_lab/domain/state.py
+++ b/src/procurement_intelligence_lab/domain/state.py
@@ -62,6 +62,7 @@ class ObservedProcurement:
     received_quantity: Decimal
     substituted_quantity: Decimal
     delayed_quantity: Decimal
+    unknown_quantity: Decimal
     scope: StateScope
     as_of: datetime
     freshness: StateFreshness

--- a/src/procurement_intelligence_lab/domain/state.py
+++ b/src/procurement_intelligence_lab/domain/state.py
@@ -1,13 +1,36 @@
-"""Canonical operational projection derived from resolved source data."""
+"""Governed expected and observed procurement-state projections."""
 
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
+from enum import StrEnum
 
-from procurement_intelligence_lab.domain.bom import Bom
+from procurement_intelligence_lab.domain.bom import Bom, EvidenceRef
 from procurement_intelligence_lab.domain.resolution import (
     ResolutionDecision,
     ResolutionStatus,
 )
+
+
+class StateFreshness(StrEnum):
+    CURRENT = "current"
+    PARTIAL = "partial"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class StateScope:
+    """The tenant/project/site/BOM-revision boundary of a state projection."""
+
+    tenant_id: str
+    project_id: str
+    site_id: str
+    bom_revision: str
+
+    def __post_init__(self) -> None:
+        if not all((self.tenant_id, self.project_id, self.site_id, self.bom_revision)):
+            raise ValueError("state scope identifiers are required")
 
 
 @dataclass(frozen=True)
@@ -16,6 +39,52 @@ class OperationalBomLine:
     quantity: Decimal
     unit_price: Decimal | None
     source_artifact: str
+    evidence: EvidenceRef
+
+
+@dataclass(frozen=True)
+class ExpectedRequirement:
+    canonical_key: str
+    required_quantity: Decimal
+    scope: StateScope
+    as_of: datetime
+    evidence: tuple[EvidenceRef, ...]
+
+    def __post_init__(self) -> None:
+        if self.as_of.tzinfo is None:
+            raise ValueError("as_of must be timezone-aware")
+
+
+@dataclass(frozen=True)
+class ObservedProcurement:
+    canonical_key: str
+    ordered_quantity: Decimal
+    received_quantity: Decimal
+    substituted_quantity: Decimal
+    delayed_quantity: Decimal
+    scope: StateScope
+    as_of: datetime
+    freshness: StateFreshness
+    evidence: tuple[EvidenceRef, ...]
+
+    def __post_init__(self) -> None:
+        if self.as_of.tzinfo is None:
+            raise ValueError("as_of must be timezone-aware")
+
+
+@dataclass(frozen=True)
+class ExpectedObservedState:
+    expected: ExpectedRequirement
+    observed: ObservedProcurement | None
+
+    @property
+    def outstanding_quantity(self) -> Decimal:
+        received = self.observed.received_quantity if self.observed is not None else Decimal(0)
+        return max(self.expected.required_quantity - received, Decimal(0))
+
+    @property
+    def freshness(self) -> StateFreshness:
+        return self.observed.freshness if self.observed is not None else StateFreshness.UNKNOWN
 
 
 def project_operational_lines(
@@ -35,6 +104,48 @@ def project_operational_lines(
                 line.quantity,
                 line.unit_price,
                 line.evidence.artifact_id,
+                line.evidence,
             )
         )
     return tuple(projected)
+
+
+def expected_requirements(
+    lines: tuple[OperationalBomLine, ...],
+    *,
+    scope: StateScope,
+    as_of: datetime,
+) -> tuple[ExpectedRequirement, ...]:
+    if as_of.tzinfo is None:
+        raise ValueError("as_of must be timezone-aware")
+    grouped: dict[str, list[OperationalBomLine]] = {}
+    for line in lines:
+        grouped.setdefault(line.canonical_key, []).append(line)
+    return tuple(
+        ExpectedRequirement(
+            canonical_key,
+            sum((line.quantity for line in group), Decimal(0)),
+            scope,
+            as_of,
+            tuple(line.evidence for line in group),
+        )
+        for canonical_key, group in sorted(grouped.items())
+    )
+
+
+def compare_expected_observed(
+    expected: tuple[ExpectedRequirement, ...],
+    observed: tuple[ObservedProcurement, ...],
+    *,
+    as_of: datetime,
+) -> tuple[ExpectedObservedState, ...]:
+    if as_of.tzinfo is None:
+        raise ValueError("as_of must be timezone-aware")
+    observed_by_key = {
+        item.canonical_key: item for item in observed if item.as_of <= as_of
+    }
+    return tuple(
+        ExpectedObservedState(item, observed_by_key.get(item.canonical_key))
+        for item in expected
+        if item.as_of <= as_of
+    )

--- a/tests/unit/test_evidence.py
+++ b/tests/unit/test_evidence.py
@@ -46,7 +46,7 @@ def test_pipeline_chain_exposes_all_drilldown_stages() -> None:
         "exact",
         _provenance(),
     )
-    line = OperationalBomLine("gpu", Decimal(4), Decimal(100), "bom.xlsx")
+    line = OperationalBomLine("gpu", Decimal(4), Decimal(100), "bom.xlsx", evidence)
 
     chain = pipeline_chain("GPU quantity", (evidence,), (decision,), (line,), "reconciled")
 

--- a/tests/unit/test_evidence_contract.py
+++ b/tests/unit/test_evidence_contract.py
@@ -74,8 +74,8 @@ def test_incomplete_price_and_unresolved_identity_abstain_from_canonical_state()
 def test_conflicting_prices_retain_both_artifacts() -> None:
     reconciled = reconcile_lines(
         (
-            OperationalBomLine("GPU-A", Decimal(1), Decimal(100), "bom-a.xlsx"),
-            OperationalBomLine("GPU-A", Decimal(1), Decimal(125), "bom-b.xlsx"),
+            OperationalBomLine("GPU-A", Decimal(1), Decimal(100), "bom-a.xlsx", line("GPU-A", "1", "100", 2).evidence),
+            OperationalBomLine("GPU-A", Decimal(1), Decimal(125), "bom-b.xlsx", line("GPU-A", "1", "125", 3).evidence),
         ),
         provenance=_provenance(),
     )

--- a/tests/unit/test_evidence_contract.py
+++ b/tests/unit/test_evidence_contract.py
@@ -74,8 +74,20 @@ def test_incomplete_price_and_unresolved_identity_abstain_from_canonical_state()
 def test_conflicting_prices_retain_both_artifacts() -> None:
     reconciled = reconcile_lines(
         (
-            OperationalBomLine("GPU-A", Decimal(1), Decimal(100), "bom-a.xlsx", line("GPU-A", "1", "100", 2).evidence),
-            OperationalBomLine("GPU-A", Decimal(1), Decimal(125), "bom-b.xlsx", line("GPU-A", "1", "125", 3).evidence),
+            OperationalBomLine(
+                "GPU-A",
+                Decimal(1),
+                Decimal(100),
+                "bom-a.xlsx",
+                line("GPU-A", "1", "100", 2).evidence,
+            ),
+            OperationalBomLine(
+                "GPU-A",
+                Decimal(1),
+                Decimal(125),
+                "bom-b.xlsx",
+                line("GPU-A", "1", "125", 3).evidence,
+            ),
         ),
         provenance=_provenance(),
     )

--- a/tests/unit/test_reconciliation.py
+++ b/tests/unit/test_reconciliation.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from procurement_intelligence_lab.domain.bom import EvidenceRef
 from procurement_intelligence_lab.domain.provenance import (
     ComponentKind,
     DecisionProvenance,
@@ -10,11 +11,12 @@ from procurement_intelligence_lab.domain.state import OperationalBomLine
 
 
 def test_reconciliation_aggregates_and_exposes_price_conflicts() -> None:
+    evidence = EvidenceRef("fixture.xlsx", "hash", "BOM", 2, ("A",))
     lines = (
-        OperationalBomLine("gpu", Decimal(4), Decimal(100), "bom-a.xlsx"),
-        OperationalBomLine("gpu", Decimal(2), Decimal(100), "bom-b.xlsx"),
-        OperationalBomLine("cpu", Decimal(1), Decimal(20), "bom-a.xlsx"),
-        OperationalBomLine("cpu", Decimal(1), Decimal(25), "bom-b.xlsx"),
+        OperationalBomLine("gpu", Decimal(4), Decimal(100), "bom-a.xlsx", evidence),
+        OperationalBomLine("gpu", Decimal(2), Decimal(100), "bom-b.xlsx", evidence),
+        OperationalBomLine("cpu", Decimal(1), Decimal(20), "bom-a.xlsx", evidence),
+        OperationalBomLine("cpu", Decimal(1), Decimal(25), "bom-b.xlsx", evidence),
     )
     provenance = DecisionProvenance(
         local_provenance_context(),

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from decimal import Decimal
 
 from procurement_intelligence_lab.domain.bom import Bom, BomLine, EvidenceRef
@@ -10,7 +11,14 @@ from procurement_intelligence_lab.domain.resolution import (
     ResolutionDecision,
     ResolutionStatus,
 )
-from procurement_intelligence_lab.domain.state import OperationalBomLine, project_operational_lines
+from procurement_intelligence_lab.domain.state import (
+    ObservedProcurement,
+    StateFreshness,
+    StateScope,
+    compare_expected_observed,
+    expected_requirements,
+    project_operational_lines,
+)
 
 
 def _provenance() -> DecisionProvenance:
@@ -22,7 +30,11 @@ def _provenance() -> DecisionProvenance:
     )
 
 
-def test_only_resolved_lines_enter_operational_state() -> None:
+def _scope() -> StateScope:
+    return StateScope("tenant", "project", "site", "bom-v1")
+
+
+def test_expected_state_preserves_resolved_evidence_and_scope() -> None:
     evidence = EvidenceRef("fixture.xlsx", "hash", "BOM", 2, ("A",))
     bom = Bom(
         "fixture.xlsx",
@@ -51,5 +63,59 @@ def test_only_resolved_lines_enter_operational_state() -> None:
     )
 
     lines = project_operational_lines(bom, decisions)
+    expected = expected_requirements(
+        lines,
+        scope=_scope(),
+        as_of=datetime(2026, 1, 1, tzinfo=UTC),
+    )
 
-    assert lines == (OperationalBomLine("gpu-canonical", Decimal(4), Decimal(100), "fixture.xlsx"),)
+    assert len(expected) == 1
+    assert expected[0].required_quantity == Decimal(4)
+    assert expected[0].scope == _scope()
+    assert expected[0].evidence == (evidence,)
+
+
+def test_expected_and_observed_state_exposes_outstanding_and_freshness() -> None:
+    evidence = EvidenceRef("fixture.xlsx", "hash", "BOM", 2, ("A",))
+    expected = expected_requirements(
+        (
+            project_operational_lines(
+                Bom(
+                    "fixture.xlsx",
+                    (BomLine("GPU-A", "GPU", Decimal(4), Decimal(100), evidence),),
+                ),
+                (
+                    ResolutionDecision(
+                        "GPU-A",
+                        "gpu-canonical",
+                        ResolutionStatus.RESOLVED,
+                        (),
+                        "exact",
+                        _provenance(),
+                    ),
+                ),
+            )[0],
+        ),
+        scope=_scope(),
+        as_of=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    observed = ObservedProcurement(
+        "gpu-canonical",
+        Decimal(4),
+        Decimal(3),
+        Decimal(0),
+        Decimal(0),
+        _scope(),
+        datetime(2026, 1, 2, tzinfo=UTC),
+        StateFreshness.PARTIAL,
+        (evidence,),
+    )
+
+    state = compare_expected_observed(
+        expected,
+        (observed,),
+        as_of=datetime(2026, 1, 2, tzinfo=UTC),
+    )[0]
+
+    assert state.outstanding_quantity == Decimal(1)
+    assert state.freshness is StateFreshness.PARTIAL

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -105,7 +105,8 @@ def test_expected_and_observed_state_exposes_outstanding_and_freshness() -> None
         Decimal(3),
         Decimal(0),
         Decimal(0),
-        _scope(),
+        Decimal(0),
+        _scope()
         datetime(2026, 1, 2, tzinfo=UTC),
         StateFreshness.PARTIAL,
         (evidence,),

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -106,7 +106,7 @@ def test_expected_and_observed_state_exposes_outstanding_and_freshness() -> None
         Decimal(0),
         Decimal(0),
         Decimal(0),
-        _scope()
+        _scope(),
         datetime(2026, 1, 2, tzinfo=UTC),
         StateFreshness.PARTIAL,
         (evidence,),


### PR DESCRIPTION
## Summary

Implements the first state-modeling slice for [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47).

- separates immutable expected requirements from observed procurement records;
- retains tenant/project/site/BOM-revision scope, evidence, and as-of context;
- represents required, ordered, received, outstanding, substituted, delayed, and unknown quantities, plus freshness;
- adds deterministic comparison without conflating state with anomaly detection, prediction, or action;
- records the boundary in ADR-020 and refreshes the handoff and M7 evidence.

## Why

PR #94 established anomaly contracts, but the repository lacked explicit expected-versus-observed state for those contracts to compare. This is the scoped state foundation before anomaly orchestration.

## Validation

- Added unit coverage for scoped expected state, evidence retention, outstanding quantity, and partial freshness.
- GitHub Actions will run `make check`.

Part of #47.