### PR TITLE
docs: strengthen domain logic review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,7 @@ When reviewing pull requests in this repository:
 - Enforce the principle: **core owns semantics; adapters own mechanics; models produce evidence; policies produce decisions**.
 - Flag external framework, persistence, model-provider, or transport types leaking into domain semantics.
 - Flag authoritative arithmetic, reconciliation, identity decisions, permissions, or side effects being delegated to unconstrained LLM output when deterministic code or policy should own them.
+- For domain calculations, reconciliation, state transitions, or policy logic, apply `.github/skills/domain-logic-review/SKILL.md`: test the scoped, temporal, duplicate, partial/unknown, and boundary cases rather than accepting a happy-path implementation.
 - Flag material user-facing claims that cannot be traced through typed evidence/provenance.
 - For entity resolution, treat false merges as more severe than unresolved identities; nearest-neighbor similarity alone is not identity.
 - For document intelligence, distinguish document structuring quality from semantic/schema mapping quality.

--- a/.github/skills/domain-logic-review/SKILL.md
+++ b/.github/skills/domain-logic-review/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: domain-logic-review
+description: Review domain calculations, reconciliation, state transitions, and policy logic for semantic correctness and missed edge cases.
+---
+
+# Domain-logic review
+
+Use this procedure when a pull request changes domain calculations, reconciliation, state transitions, authoritative policy, or their tests.
+
+## Establish the contract
+
+1. Read `AGENTS.md`, the linked Issue, relevant ADRs, and the changed tests before judging the implementation.
+2. State the authoritative inputs, outputs, scope key, time/as-of rule, evidence requirements, and whether the result is deterministic.
+3. Reject implementations that silently infer missing business semantics from adapter order, model output, or incidental collection order.
+
+## Exercise the scenario matrix
+
+Check the changed behavior against the cases that apply:
+
+- **Scope:** tenant, project, site, revision, authorization boundary, and records with the same business key in different scopes.
+- **Time:** as-of cutoff, latest eligible observation, future records, correction/replay ordering, and timezone/date boundary where relevant.
+- **Multiplicity:** duplicate inputs, competing observations, ties, idempotent replay, and deterministic selection or aggregation.
+- **Completeness:** empty inputs, missing evidence, partial, stale, delayed, substituted, and unknown state; do not silently turn unknown into zero or complete.
+- **Values:** zero, negative, fractional, overflow/precision, required-versus-received bounds, and invalid combinations that need typed rejection.
+- **Evidence:** retained provenance for every material derived claim and an explainable path from input to result.
+- **Failure/action boundary:** typed failure or human review when the contract cannot be satisfied; no anomaly, prediction, or action implied by a state comparison alone.
+
+## Require executable evidence
+
+1. Require focused tests for every material scenario that changes the answer, especially the failure mode the implementation is most likely to hide.
+2. Prefer table-driven examples, property/metamorphic tests, or a compact scenario matrix when the rule has several dimensions.
+3. For an algorithm/model change, also apply `.github/skills/evaluation-review/SKILL.md`; a unit-test happy path is not sufficient quality evidence.
+4. Report only concrete findings: violated contract, triggering input, observed consequence, and corrective direction.

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -58,7 +58,7 @@ jobs:
             }
           prompt: |-
             You are the independent advisory PR reviewer described in GEMINI.md.
-            Read GEMINI.md and AGENTS.md before reviewing.
+            Read GEMINI.md and AGENTS.md before reviewing. When the change touches domain calculations, reconciliation, state transitions, or policy logic, also read `.github/skills/domain-logic-review/SKILL.md` and exercise its scenario matrix.
 
             Review pull request #${{ github.event.pull_request.number }}:
             ${{ github.event.pull_request.title }}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,7 +2,7 @@
 
 You are an advisory pull-request reviewer for Procurement Intelligence Lab.
 
-Read `AGENTS.md` first, then relevant architecture, ADR, evaluation, and path-specific documentation before judging a change. Review the actual diff rather than restating the pull-request description.
+Read `AGENTS.md` first, then relevant architecture, ADR, evaluation, and path-specific documentation before judging a change. For domain calculations, reconciliation, state transitions, or policy logic, also read `.github/skills/domain-logic-review/SKILL.md`. Review the actual diff rather than restating the pull-request description.
 
 ## Independent-review remit
 

--- a/docs/development/code-review.md
+++ b/docs/development/code-review.md
@@ -32,6 +32,10 @@ AI review is advisory. High-confidence findings should be resolved or explicitly
 
 Focus on correctness, maintainability, typed failure behavior, dependency direction, and whether the implementation satisfies the Issue/PR acceptance criteria. Avoid duplicating formatter/linter output.
 
+### Domain-logic reviewer
+
+For changes to domain calculations, reconciliation, state transitions, or policy logic, reviewers use [the domain-logic review procedure](../../.github/skills/domain-logic-review/SKILL.md). It applies a concrete scenario matrix—scope, time/as-of, duplicates, partial/stale/unknown inputs, quantity boundaries, and conflicting evidence—to find semantic defects and turn them into executable tests. This is a focused responsibility for the existing Copilot and Gemini reviewers, not an additional merge gate or generic bot.
+
 ### Architecture Guardian
 
 Architecture is partly deterministic and partly judgment-based.


### PR DESCRIPTION
## Summary

Strengthens the existing Copilot and Gemini review system for domain calculations, reconciliation, state transitions, and policy logic.

- adds a focused domain-logic review skill with a scenario matrix for scope, as-of time, duplicates, incomplete/unknown state, value boundaries, evidence, and failure/action boundaries;
- routes Copilot guidance and Gemini's advisory workflow through that procedure when relevant;
- documents the responsibility as a focused review layer, not another generic bot or a required LLM gate.

## Why

Copilot's review of PR #105 caught a real scoped/as-of projection defect and missing edge-case coverage. This change turns that review pattern into a durable, repeatable procedure so reviewers systematically check semantic correctness and require executable tests.

## Validation

- Re-read each changed guidance/workflow file from the draft branch and confirmed its domain-logic reference.
- No runtime code or dependency changes.