### PR TITLE
feat: orchestrate expected-state anomalies

### DIFF
--- a/docs/adr/016-expected-observed-anomalies.md
+++ b/docs/adr/016-expected-observed-anomalies.md
@@ -16,6 +16,7 @@ Define a framework-independent anomaly contract:
 - Anomaly is immutable and carries the subject, expected and observed values, severity, lifecycle status, policy identifier, detection timestamp, and source evidence.
 - AnomalyPolicy holds explicit non-negative quantity, price, and schedule tolerances.
 - Deterministic helpers emit an open warning only when a comparison exceeds the configured tolerance. They return no anomaly within tolerance.
+- State orchestration consumes `ExpectedObservedState`: it emits missing-PO, quantity-mismatch, substitution, and coverage-gap anomalies where the state contract provides the required inputs. It does not infer revision, price, schedule, or identity anomalies from incomplete state.
 - Detection timestamps must be timezone-aware. Anomaly IDs are stable for the same semantic inputs and evidence references.
 
 This slice provides the core contract and representative deterministic comparisons. Broader detection orchestration and durable anomaly persistence remain later work.

--- a/docs/project/handoff.md
+++ b/docs/project/handoff.md
@@ -8,7 +8,7 @@ Start with [AGENTS.md](../../AGENTS.md), then read the relevant [GitHub Issue](h
 
 ## Current milestone and status
 
-- **M7 — Append-only persistence, temporal/as-of state, anomaly taxonomy, and execution provenance:** in progress. The ledger boundary and the first anomaly/provenance contract are on `main`; remaining work includes expected-versus-observed state, temporal correction, durable storage, and anomaly orchestration. See the [canonical milestone map](../development/milestone-map.md), [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47), and [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60).
+- **M7 — Append-only persistence, temporal/as-of state, anomaly taxonomy, and execution provenance:** in progress. The ledger boundary and the first anomaly/provenance contract are on `main`; remaining work includes temporal correction, durable storage, and anomaly orchestration. See the [canonical milestone map](../development/milestone-map.md) and [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60).
 - **M8 — Retrieval projections and review UI:** in progress. The rebuildable projection lifecycle foundation is complete; later adapter work remains. See [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54).
 - **M9 — Guarded actions, product signals, and integrated evaluation:** planned.
 - The initial M0–M6 evidence-first vertical slice is complete on `main`; the [root README](../../README.md) records the current product boundary and runnable entry points.
@@ -32,7 +32,7 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 
 ## Active work and PRs
 
-- Expected-versus-observed state is complete; [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47) can close after this acceptance-evidence PR merges. The next M7 slice is temporal correction and anomaly orchestration.
+- [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47) is complete. [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60) is active: begin deterministic orchestration only from explicit scoped expected and observed state.
 - [Issue #54](https://github.com/stauntonjr/procurement-intelligence-lab/issues/54) is complete. Follow-on M8 work includes [Issues #55, #57, #59, #62, and #63](https://github.com/stauntonjr/procurement-intelligence-lab/issues/63); preserve their dependencies and evaluation gates.
 - M6 identity, source-viewer, and review-context work is complete; see [Issues #85, #87, and #89](https://github.com/stauntonjr/procurement-intelligence-lab/issues/89).
 
@@ -55,7 +55,7 @@ The system preserves evidence from synthetic/semi-structured procurement documen
 
 ## Recommended next work
 
-1. Close [Issue #47](https://github.com/stauntonjr/procurement-intelligence-lab/issues/47) once its acceptance evidence is merged, then extend anomaly orchestration only from explicit scoped expected and observed state.
+1. Extend [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60) from explicit scoped expected and observed state; keep anomaly detection distinct from prediction, decisions, and actions.
 2. Run the [roadmap stewardship protocol](../development/roadmap-stewardship.md) and resolve confirmed durable-record drift through normal Issues and PRs.
 3. Sequence later retrieval adapters only after their prerequisites, scope filters, and evaluation evidence are ready.
 4. Before selecting retrieval or agent frameworks, run the repository's stated evaluation and benchmark work.

--- a/src/procurement_intelligence_lab/domain/anomalies.py
+++ b/src/procurement_intelligence_lab/domain/anomalies.py
@@ -102,7 +102,7 @@ def detect_expected_observed_anomalies(
     subject_key = _state_subject_key(state)
     anomalies: list[Anomaly] = []
 
-    if observed is None or observed.ordered_quantity <= policy.quantity_tolerance:
+if observed is None or observed.ordered_quantity <= Decimal(0):
         if expected.required_quantity > policy.quantity_tolerance:
             anomalies.append(
                 Anomaly(

--- a/src/procurement_intelligence_lab/domain/anomalies.py
+++ b/src/procurement_intelligence_lab/domain/anomalies.py
@@ -89,7 +89,6 @@ class Anomaly:
 
 
 
-
 def detect_expected_observed_anomalies(
     state: ExpectedObservedState,
     *,

--- a/src/procurement_intelligence_lab/domain/anomalies.py
+++ b/src/procurement_intelligence_lab/domain/anomalies.py
@@ -88,7 +88,6 @@ class Anomaly:
         )
 
 
-
 def detect_expected_observed_anomalies(
     state: ExpectedObservedState,
     *,
@@ -189,6 +188,7 @@ def _state_evidence(state: ExpectedObservedState) -> tuple[EvidenceRef, ...]:
     if state.observed is not None:
         evidence.extend(state.observed.evidence)
     return tuple({ref.evidence_id: ref for ref in evidence}.values())
+
 
 def detect_quantity_mismatch(
     subject_key: str,

--- a/src/procurement_intelligence_lab/domain/anomalies.py
+++ b/src/procurement_intelligence_lab/domain/anomalies.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from procurement_intelligence_lab.domain.bom import EvidenceRef
 from procurement_intelligence_lab.domain.identity import stable_id
 from procurement_intelligence_lab.domain.provenance import DecisionProvenance
+from procurement_intelligence_lab.domain.state import ExpectedObservedState, StateFreshness
 
 
 class AnomalyKind(StrEnum):
@@ -86,6 +87,109 @@ class Anomaly:
             self.provenance.provenance_id,
         )
 
+
+
+
+def detect_expected_observed_anomalies(
+    state: ExpectedObservedState,
+    *,
+    policy: AnomalyPolicy,
+    provenance: DecisionProvenance,
+    detected_at: datetime,
+) -> tuple[Anomaly, ...]:
+    """Detect deterministic state deviations without predicting or acting."""
+    expected = state.expected
+    observed = state.observed
+    evidence = _state_evidence(state)
+    subject_key = _state_subject_key(state)
+    anomalies: list[Anomaly] = []
+
+    if observed is None or observed.ordered_quantity <= policy.quantity_tolerance:
+        if expected.required_quantity > policy.quantity_tolerance:
+            anomalies.append(
+                Anomaly(
+                    subject_key,
+                    AnomalyKind.MISSING_PO,
+                    expected.required_quantity,
+                    None if observed is None else observed.ordered_quantity,
+                    AnomalySeverity.WARNING,
+                    AnomalyStatus.OPEN,
+                    evidence,
+                    policy.policy_id,
+                    provenance,
+                    detected_at,
+                )
+            )
+    elif abs(observed.ordered_quantity - expected.required_quantity) > policy.quantity_tolerance:
+        anomalies.append(
+            Anomaly(
+                subject_key,
+                AnomalyKind.QUANTITY_MISMATCH,
+                expected.required_quantity,
+                observed.ordered_quantity,
+                AnomalySeverity.WARNING,
+                AnomalyStatus.OPEN,
+                evidence,
+                policy.policy_id,
+                provenance,
+                detected_at,
+            )
+        )
+
+    if observed is None:
+        return tuple(anomalies)
+
+    if observed.substituted_quantity > policy.quantity_tolerance:
+        anomalies.append(
+            Anomaly(
+                subject_key,
+                AnomalyKind.SUBSTITUTION,
+                Decimal(0),
+                observed.substituted_quantity,
+                AnomalySeverity.WARNING,
+                AnomalyStatus.OPEN,
+                evidence,
+                policy.policy_id,
+                provenance,
+                detected_at,
+            )
+        )
+
+    if (
+        observed.freshness is not StateFreshness.CURRENT
+        or observed.unknown_quantity > policy.quantity_tolerance
+    ):
+        anomalies.append(
+            Anomaly(
+                subject_key,
+                AnomalyKind.COVERAGE_GAP,
+                expected.required_quantity,
+                observed.unknown_quantity,
+                AnomalySeverity.INFO,
+                AnomalyStatus.OPEN,
+                evidence,
+                policy.policy_id,
+                provenance,
+                detected_at,
+            )
+        )
+
+    return tuple(anomalies)
+
+
+def _state_subject_key(state: ExpectedObservedState) -> str:
+    scope = state.expected.scope
+    return (
+        f"{scope.tenant_id}/{scope.project_id}/{scope.site_id}/"
+        f"{scope.bom_revision}:{state.expected.canonical_key}"
+    )
+
+
+def _state_evidence(state: ExpectedObservedState) -> tuple[EvidenceRef, ...]:
+    evidence = list(state.expected.evidence)
+    if state.observed is not None:
+        evidence.extend(state.observed.evidence)
+    return tuple({ref.evidence_id: ref for ref in evidence}.values())
 
 def detect_quantity_mismatch(
     subject_key: str,

--- a/src/procurement_intelligence_lab/domain/anomalies.py
+++ b/src/procurement_intelligence_lab/domain/anomalies.py
@@ -102,7 +102,7 @@ def detect_expected_observed_anomalies(
     subject_key = _state_subject_key(state)
     anomalies: list[Anomaly] = []
 
-if observed is None or observed.ordered_quantity <= Decimal(0):
+    if observed is None or observed.ordered_quantity <= Decimal(0):
         if expected.required_quantity > policy.quantity_tolerance:
             anomalies.append(
                 Anomaly(

--- a/tests/unit/test_anomalies.py
+++ b/tests/unit/test_anomalies.py
@@ -9,11 +9,19 @@ from procurement_intelligence_lab.domain.anomalies import (
     AnomalyPolicy,
     AnomalySeverity,
     AnomalyStatus,
+    detect_expected_observed_anomalies,
     detect_late_commitment,
     detect_price_deviation,
     detect_quantity_mismatch,
 )
 from procurement_intelligence_lab.domain.bom import EvidenceRef
+from procurement_intelligence_lab.domain.state import (
+    ExpectedObservedState,
+    ExpectedRequirement,
+    ObservedProcurement,
+    StateFreshness,
+    StateScope,
+)
 from procurement_intelligence_lab.domain.provenance import (
     ComponentKind,
     DecisionProvenance,
@@ -205,3 +213,72 @@ def test_anomalies_require_timezone_aware_detection_time(
             provenance,
             datetime(2026, 1, 10),  # noqa: DTZ001
         )
+
+
+def _state_scope() -> StateScope:
+    return StateScope("tenant", "project", "site", "bom-v1")
+
+
+def test_state_orchestration_distinguishes_missing_po_from_quantity_mismatch(
+    evidence: tuple[EvidenceRef, ...],
+    detected_at: datetime,
+    provenance: DecisionProvenance,
+) -> None:
+    expected = ExpectedRequirement(
+        "GPU-A",
+        Decimal(4),
+        _state_scope(),
+        datetime(2026, 1, 1, tzinfo=UTC),
+        evidence,
+    )
+
+    anomalies = detect_expected_observed_anomalies(
+        ExpectedObservedState(expected, None),
+        policy=AnomalyPolicy("state-v1"),
+        provenance=provenance,
+        detected_at=detected_at,
+    )
+
+    assert [anomaly.kind for anomaly in anomalies] == [AnomalyKind.MISSING_PO]
+    assert anomalies[0].subject_key == "tenant/project/site/bom-v1:GPU-A"
+    assert anomalies[0].evidence == evidence
+
+
+def test_state_orchestration_preserves_scope_and_incomplete_observation(
+    evidence: tuple[EvidenceRef, ...],
+    detected_at: datetime,
+    provenance: DecisionProvenance,
+) -> None:
+    expected = ExpectedRequirement(
+        "GPU-A",
+        Decimal(4),
+        _state_scope(),
+        datetime(2026, 1, 1, tzinfo=UTC),
+        evidence,
+    )
+    observed = ObservedProcurement(
+        "GPU-A",
+        Decimal(2),
+        Decimal(1),
+        Decimal(1),
+        Decimal(0),
+        Decimal(1),
+        _state_scope(),
+        datetime(2026, 1, 2, tzinfo=UTC),
+        StateFreshness.PARTIAL,
+        evidence,
+    )
+
+    anomalies = detect_expected_observed_anomalies(
+        ExpectedObservedState(expected, observed),
+        policy=AnomalyPolicy("state-v1"),
+        provenance=provenance,
+        detected_at=detected_at,
+    )
+
+    assert [anomaly.kind for anomaly in anomalies] == [
+        AnomalyKind.QUANTITY_MISMATCH,
+        AnomalyKind.SUBSTITUTION,
+        AnomalyKind.COVERAGE_GAP,
+    ]
+    assert anomalies[-1].severity is AnomalySeverity.INFO

--- a/tests/unit/test_anomalies.py
+++ b/tests/unit/test_anomalies.py
@@ -282,3 +282,38 @@ def test_state_orchestration_preserves_scope_and_incomplete_observation(
         AnomalyKind.COVERAGE_GAP,
     ]
     assert anomalies[-1].severity is AnomalySeverity.INFO
+
+
+def test_state_orchestration_tolerance_does_not_hide_nonzero_order(
+    evidence: tuple[EvidenceRef, ...],
+    detected_at: datetime,
+    provenance: DecisionProvenance,
+) -> None:
+    expected = ExpectedRequirement(
+        "GPU-A",
+        Decimal(4),
+        _state_scope(),
+        datetime(2026, 1, 1, tzinfo=UTC),
+        evidence,
+    )
+    observed = ObservedProcurement(
+        "GPU-A",
+        Decimal(1),
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        _state_scope(),
+        datetime(2026, 1, 2, tzinfo=UTC),
+        StateFreshness.CURRENT,
+        evidence,
+    )
+
+    anomalies = detect_expected_observed_anomalies(
+        ExpectedObservedState(expected, observed),
+        policy=AnomalyPolicy("state-v1", quantity_tolerance=Decimal(1)),
+        provenance=provenance,
+        detected_at=detected_at,
+    )
+
+    assert [anomaly.kind for anomaly in anomalies] == [AnomalyKind.QUANTITY_MISMATCH]

--- a/tests/unit/test_anomalies.py
+++ b/tests/unit/test_anomalies.py
@@ -282,3 +282,41 @@ def test_state_orchestration_preserves_scope_and_incomplete_observation(
         AnomalyKind.COVERAGE_GAP,
     ]
     assert anomalies[-1].severity is AnomalySeverity.INFO
+
+
+def test_state_orchestration_nonzero_tolerance_classifies_small_order_as_quantity_mismatch_not_missing_po(
+    evidence: tuple[EvidenceRef, ...],
+    detected_at: datetime,
+    provenance: DecisionProvenance,
+) -> None:
+    """ordered=1, expected=4, tolerance=1: should be QUANTITY_MISMATCH, not MISSING_PO."""
+    expected = ExpectedRequirement(
+        "GPU-A",
+        Decimal(4),
+        _state_scope(),
+        datetime(2026, 1, 1, tzinfo=UTC),
+        evidence,
+    )
+    observed = ObservedProcurement(
+        "GPU-A",
+        Decimal(1),
+        Decimal(1),
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        _state_scope(),
+        datetime(2026, 1, 2, tzinfo=UTC),
+        StateFreshness.CURRENT,
+        evidence,
+    )
+
+    anomalies = detect_expected_observed_anomalies(
+        ExpectedObservedState(expected, observed),
+        policy=AnomalyPolicy("state-v1", quantity_tolerance=Decimal(1)),
+        provenance=provenance,
+        detected_at=detected_at,
+    )
+
+    kinds = [anomaly.kind for anomaly in anomalies]
+    assert AnomalyKind.MISSING_PO not in kinds
+    assert AnomalyKind.QUANTITY_MISMATCH in kinds

--- a/tests/unit/test_anomalies.py
+++ b/tests/unit/test_anomalies.py
@@ -15,16 +15,16 @@ from procurement_intelligence_lab.domain.anomalies import (
     detect_quantity_mismatch,
 )
 from procurement_intelligence_lab.domain.bom import EvidenceRef
+from procurement_intelligence_lab.domain.provenance import (
+    ComponentKind,
+    DecisionProvenance,
+)
 from procurement_intelligence_lab.domain.state import (
     ExpectedObservedState,
     ExpectedRequirement,
     ObservedProcurement,
     StateFreshness,
     StateScope,
-)
-from procurement_intelligence_lab.domain.provenance import (
-    ComponentKind,
-    DecisionProvenance,
 )
 
 


### PR DESCRIPTION
## Summary

Implements the first deterministic anomaly orchestration slice for [Issue #60](https://github.com/stauntonjr/procurement-intelligence-lab/issues/60).

- consumes explicit `ExpectedObservedState` rather than raw documents or model output;
- emits typed missing-PO, quantity-mismatch, substitution, and coverage-gap anomalies with scoped subject keys, policy identifiers, provenance, and combined evidence;
- makes incomplete/partial observations visible without treating them as a prediction, decision, or action;
- records the state-input boundary in ADR-016 and refreshes the handoff after Issue #47 closed.

## Why

Expected-versus-observed state is now deterministic and scoped. This turns the subset of anomaly taxonomy supported by that state into explainable findings while explicitly abstaining from revision, price, schedule, and identity findings until their separate inputs exist.

## Validation

- Added regression coverage for missing PO and a partial substituted observation with quantity mismatch and a coverage gap.
- Re-read the code, tests, ADR, and handoff from the draft branch.
- No model, external service, or remediation behavior.

Part of #60.